### PR TITLE
[FEAT] 글로벌 응답 포맷(ApiResponse) 구조 도입 및 예외 처리 통일

### DIFF
--- a/woorepie/src/main/java/com/piehouse/woorepie/global/exception/CustomException.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.piehouse.woorepie.global.exception;
+
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/exception/ErrorCode.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/exception/ErrorCode.java
@@ -1,0 +1,43 @@
+package com.piehouse.woorepie.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+    // 400: 잘못된 요청
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다."),
+
+    // 401: 인증 실패
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+
+    // 403: 권한 없음
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    // 404: 리소스 없음
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+
+    // 409: 리소스 충돌
+    DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
+
+    // 500: 서버 에러
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/exception/GlobalExceptionHandler.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.piehouse.woorepie.global.exception;
+
+import com.piehouse.woorepie.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException ex, HttpServletRequest request) {
+        ErrorCode errorCode = ex.getErrorCode();
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(new ApiResponse<>(
+                        LocalDateTime.now(),
+                        errorCode.getHttpStatus().value(),
+                        errorCode.getMessage(),
+                        request.getRequestURI(),
+                        null
+                ));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception ex, HttpServletRequest request) {
+        ex.printStackTrace(); // 로그 출력
+        return ResponseEntity.internalServerError().body(
+                new ApiResponse<>(
+                        LocalDateTime.now(),
+                        500,
+                        "알 수 없는 서버 오류",
+                        request.getRequestURI(),
+                        null
+                )
+        );
+    }
+}

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/response/ApiResponse.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/response/ApiResponse.java
@@ -1,0 +1,15 @@
+package com.piehouse.woorepie.global.response;
+
+import java.time.LocalDateTime;
+
+public record ApiResponse<T>(
+        LocalDateTime timestamp,
+        int status,
+        String message,
+        String path,
+        T data
+) {
+    public static <T> ApiResponse<T> of(int status, String message, String path, T data) {
+        return new ApiResponse<>(LocalDateTime.now(), status, message, path, data);
+    }
+}

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/response/ApiResponse.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/response/ApiResponse.java
@@ -1,7 +1,10 @@
 package com.piehouse.woorepie.global.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.time.LocalDateTime;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ApiResponse<T>(
         LocalDateTime timestamp,
         int status,

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/response/ApiResponseUtil.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/response/ApiResponseUtil.java
@@ -1,0 +1,19 @@
+package com.piehouse.woorepie.global.response;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class ApiResponseUtil {
+
+    public static <T> ResponseEntity<ApiResponse<T>> success(T data, HttpServletRequest request) {
+        return ResponseEntity.ok(
+                ApiResponse.of(HttpStatus.OK.value(), "요청 성공", request.getRequestURI(), data)
+        );
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> of(HttpStatus status, String message, T data, HttpServletRequest request) {
+        return ResponseEntity.status(status)
+                .body(ApiResponse.of(status.value(), message, request.getRequestURI(), data));
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요
- 모든 API의 성공/실패 응답을 하나의 공통 JSON 구조 (ApiResponse<T>)로 통일하였습니다. 
- 프론트엔드와의 협업 효율을 높이고, 로깅 및 예외 디버깅을 고려한 구조입니다.

## ✅ 작업 목록
- [x] ApiResponse<T> record 클래스 도입 (timestamp, status, message, path, data)
- [x] ApiResponseUtil 유틸 생성 (success(), of() 메서드로 응답 생성)
- [x] ErrorCode, CustomException, GlobalExceptionHandler 구성

## 📎 관련 이슈
- resolve #1