### PR TITLE
[FEAT] Redis에 남은 토큰 수량 저장, 조회, 수정

### DIFF
--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/repository/EstateRepository.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/repository/EstateRepository.java
@@ -4,7 +4,9 @@ import com.piehouse.woorepie.estate.entity.Estate;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface EstateRepository extends JpaRepository<Estate, Long> {
-
+    Optional<Integer> findTokenAmountByEstateId(Long estateId);
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/service/EstateRedisService.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/service/EstateRedisService.java
@@ -1,0 +1,15 @@
+package com.piehouse.woorepie.estate.service;
+
+public interface EstateRedisService {
+    // 1. 남은 토큰 수량 저장 (STRING)
+    public void setRemainingTokens(String estateId, int remainingTokens);
+
+    // 2. 남은 토큰 수량 조회
+    public int getRemainingTokens(String estateId);
+
+    // 3. 토큰 수량 감소 (원자적 연산)
+    public Long decrementTokens(String estateId, int amount);
+
+    // 4. 토큰 수량 증가 (원자적 연산)
+    public Long incrementTokens(String estateId, int amount);
+}

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/service/EstateRedisService.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/service/EstateRedisService.java
@@ -1,15 +1,18 @@
 package com.piehouse.woorepie.estate.service;
 
 public interface EstateRedisService {
-    // 1. 남은 토큰 수량 저장 (STRING)
-    public void setRemainingTokens(String estateId, int remainingTokens);
+    // 청약 오픈 시 PostgreSQL에서 tokenAmount를 읽어와 Redis에 초기화
+    void initializeRemainingTokens(Long estateId);
 
-    // 2. 남은 토큰 수량 조회
-    public int getRemainingTokens(String estateId);
+    // 남은 토큰 수량 Reids에 저장 (STRING)
+    void setRemainingTokens(String estateId, int remainingTokens);
 
-    // 3. 토큰 수량 감소 (원자적 연산)
-    public Long decrementTokens(String estateId, int amount);
+    // 남은 토큰 수량 Redis에서 조회
+    int getRemainingTokens(String estateId);
 
-    // 4. 토큰 수량 증가 (원자적 연산)
-    public Long incrementTokens(String estateId, int amount);
+    // 토큰 수량 감소 (원자적 연산)
+    Long decrementTokens(String estateId, int amount);
+
+    // 토큰 수량 증가 (원자적 연산)
+    Long incrementTokens(String estateId, int amount);
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/service/implement/EstateRedisServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/service/implement/EstateRedisServiceImpl.java
@@ -1,0 +1,39 @@
+package com.piehouse.woorepie.estate.service.implement;
+
+import com.piehouse.woorepie.estate.service.EstateRedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EstateRedisServiceImpl implements EstateRedisService {
+    private final RedisTemplate<String, String> redisStringTemplate;
+
+    private static final String REMAINING_TOKENS_KEY_FORMAT = "subscription:%s:remaining-tokens"; // estateId
+
+    // 1. 남은 토큰 수량 저장 (STRING)
+    public void setRemainingTokens(String estateId, int remainingTokens) {
+        String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
+        redisStringTemplate.opsForValue().set(key, String.valueOf(remainingTokens));
+    }
+
+    // 2. 남은 토큰 수량 조회
+    public int getRemainingTokens(String estateId) {
+        String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
+        String value = redisStringTemplate.opsForValue().get(key);
+        return value != null ? Integer.parseInt(value) : 0;
+    }
+
+    // 3. 토큰 수량 감소 (원자적 연산)
+    public Long decrementTokens(String estateId, int amount) {
+        String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
+        return redisStringTemplate.opsForValue().decrement(key, amount);
+    }
+
+    // 4. 토큰 수량 증가 (원자적 연산)
+    public Long incrementTokens(String estateId, int amount) {
+        String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
+        return redisStringTemplate.opsForValue().increment(key, amount);
+    }
+}

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/service/implement/EstateRedisServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/service/implement/EstateRedisServiceImpl.java
@@ -1,37 +1,54 @@
 package com.piehouse.woorepie.estate.service.implement;
 
+import com.piehouse.woorepie.estate.repository.EstateRepository;
 import com.piehouse.woorepie.estate.service.EstateRedisService;
+import com.piehouse.woorepie.global.exception.CustomException;
+import com.piehouse.woorepie.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class EstateRedisServiceImpl implements EstateRedisService {
     private final RedisTemplate<String, String> redisStringTemplate;
+    private final EstateRepository estateRepository;
 
     private static final String REMAINING_TOKENS_KEY_FORMAT = "subscription:%s:remaining-tokens"; // estateId
 
-    // 1. 남은 토큰 수량 저장 (STRING)
+    // 청약 오픈 시 PostgreSQL에서 tokenAmount를 읽어와 Redis에 초기화
+    @Transactional(readOnly = true)
+    public void initializeRemainingTokens(Long estateId) {
+        // 1. DB에서 tokenAmount 조회
+        Integer tokenAmount = estateRepository.findTokenAmountByEstateId(estateId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ESTATE_NOT_FOUND));
+
+        // 2. Redis에 저장 (초기화)
+        String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
+        redisStringTemplate.opsForValue().set(key, String.valueOf(tokenAmount));
+    }
+
+    // 남은 토큰 수량 Reids에 저장 (STRING)
     public void setRemainingTokens(String estateId, int remainingTokens) {
         String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
         redisStringTemplate.opsForValue().set(key, String.valueOf(remainingTokens));
     }
 
-    // 2. 남은 토큰 수량 조회
+    // 남은 토큰 수량 Redis에서 조회
     public int getRemainingTokens(String estateId) {
         String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
         String value = redisStringTemplate.opsForValue().get(key);
         return value != null ? Integer.parseInt(value) : 0;
     }
 
-    // 3. 토큰 수량 감소 (원자적 연산)
+    // 토큰 수량 감소 (원자적 연산)
     public Long decrementTokens(String estateId, int amount) {
         String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
         return redisStringTemplate.opsForValue().decrement(key, amount);
     }
 
-    // 4. 토큰 수량 증가 (원자적 연산)
+    // 토큰 수량 증가 (원자적 연산)
     public Long incrementTokens(String estateId, int amount) {
         String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
         return redisStringTemplate.opsForValue().increment(key, amount);


### PR DESCRIPTION
## ✨ 작업 개요
청약 신청할 때 필요한 남은 토큰 수량을 Redis에 저장, 조회, 수정 구현

## ✅ 작업 목록
- [x] PostgreSQL에서 tokenAmount를 읽어와 Redis에 초기화 및 저장
- [x] 남은 토큰 수량 조회
- [x] 남은 토큰 수량 수정

## 📎 관련 이슈
- resolve #39