### PR TITLE
[FEAT] Dockerfile 추가

### DIFF
--- a/woorepie/Dockerfile
+++ b/woorepie/Dockerfile
@@ -1,0 +1,9 @@
+FROM eclipse-temurin:17-jre-alpine
+
+WORKDIR /app
+
+ARG JAR_FILE=build/libs/*.jar
+
+COPY ${JAR_FILE} app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## ✨ 작업 개요
Spring Boot 애플리케이션 배포를 위한 Dockerfile을 추가했습니다.

- Eclipse Temurin JDK 17 기반의 경량 Alpine 이미지 사용
- Gradle 빌드 결과물인 `build/libs/*.jar`를 복사해 `java -jar`로 실행하도록 구성

## ✅ 작업 목록
- [x] JDK 17 기반 Dockerfile 작성
- [x] JAR 파일 실행 설정 적용

## 📎 관련 이슈
- #56