### PR TITLE
[FIX] Dockerfile COPY 위치 수정

### DIFF
--- a/woorepie/Dockerfile
+++ b/woorepie/Dockerfile
@@ -2,8 +2,6 @@ FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR /app
 
-ARG JAR_FILE=build/libs/*.jar
-
-COPY ${JAR_FILE} app.jar
+COPY woorepie/build/libs/*.jar app.jar
 
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## ✨ 작업 개요
Docker 이미지 빌드 시 JAR 파일 경로 문제를 해결하기 위해, Dockerfile의 COPY 경로를 수정

## ✅ 작업 목록
- [x] Dockerfile에서 JAR 파일 복사 경로를 woorepie/build/libs/*.jar로 수정

## 📎 관련 이슈
- #56