### PR TITLE
[FIX] Dockerfile jar 파일명 고정

### DIFF
--- a/woorepie/Dockerfile
+++ b/woorepie/Dockerfile
@@ -2,6 +2,6 @@ FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR /app
 
-COPY woorepie/build/libs/*.jar app.jar
+COPY woorepie/build/libs/*.jar /app/
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "woorepie-0.0.1-SNAPSHOT.jar"]


### PR DESCRIPTION
## ✨ 작업 개요
Dockerfile jar 파일명 고정

## ✅ 작업 목록
- [x] Jenkins/Kaniko 빌드 시 Kaniko의 다중 파일 COPY 에러 해결 확인
- [x] ENTRYPOINT에서 실제 실행할 JAR 파일명(woorepie-0.0.1-SNAPSHOT.jar)을 명확히 지정

## 📎 관련 이슈
- #56