### PR TITLE
[FIX] 청약 일괄 처리로 로직 수정 및 엔티티 상태 필드 구조 변경

### DIFF
--- a/woorepie/src/main/java/com/piehouse/woorepie/WoorepieApplication.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/WoorepieApplication.java
@@ -2,8 +2,10 @@ package com.piehouse.woorepie;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class WoorepieApplication {
 
     public static void main(String[] args) {

--- a/woorepie/src/main/java/com/piehouse/woorepie/WoorepieApplication.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/WoorepieApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 public class WoorepieApplication {
 
     public static void main(String[] args) {

--- a/woorepie/src/main/java/com/piehouse/woorepie/customer/dto/response/GetCustomerSubscriptionResponse.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/customer/dto/response/GetCustomerSubscriptionResponse.java
@@ -1,6 +1,6 @@
 package com.piehouse.woorepie.customer.dto.response;
 
-import com.piehouse.woorepie.estate.entity.EstateStatus;
+import com.piehouse.woorepie.subscription.entity.SubStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +24,6 @@ public class GetCustomerSubscriptionResponse {
 
     private LocalDateTime subDate;
 
-    private EstateStatus subStatus;
+    private SubStatus subStatus;
 
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/customer/dto/response/GetCustomerSubscriptionResponse.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/customer/dto/response/GetCustomerSubscriptionResponse.java
@@ -1,6 +1,6 @@
 package com.piehouse.woorepie.customer.dto.response;
 
-import com.piehouse.woorepie.estate.entity.SubState;
+import com.piehouse.woorepie.estate.entity.EstateStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +24,6 @@ public class GetCustomerSubscriptionResponse {
 
     private LocalDateTime subDate;
 
-    private SubState subStatus;
+    private EstateStatus subStatus;
 
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/customer/entity/Customer.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/customer/entity/Customer.java
@@ -59,6 +59,9 @@ public class Customer {
     @Column(length = 1000, nullable = false, unique = true)
     private String customerIdentificationUrl;
 
+    @Version
+    private Long version;
+
     // 계좌 잔액 감소 메서드 추가
     public void decreaseBalance(int amount) {
         if (this.accountBalance < amount) {

--- a/woorepie/src/main/java/com/piehouse/woorepie/customer/entity/Customer.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/customer/entity/Customer.java
@@ -59,9 +59,6 @@ public class Customer {
     @Column(length = 1000, nullable = false, unique = true)
     private String customerIdentificationUrl;
 
-    @Version
-    private Long version;
-
     // 계좌 잔액 감소 메서드 추가
     public void decreaseBalance(int amount) {
         if (this.accountBalance < amount) {

--- a/woorepie/src/main/java/com/piehouse/woorepie/customer/repository/CustomerRepository.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/customer/repository/CustomerRepository.java
@@ -2,6 +2,9 @@ package com.piehouse.woorepie.customer.repository;
 
 import com.piehouse.woorepie.customer.entity.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -17,4 +20,7 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
 
     Optional<Customer> findByCustomerEmail(String email);
 
+    @Modifying
+    @Query("UPDATE Customer c SET c.accountBalance = c.accountBalance - :amount WHERE c.customerId = :customerId AND c.accountBalance >= :amount")
+    int decreaseBalance(@Param("customerId") Long customerId, @Param("amount") int amount);
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/customer/repository/CustomerRepository.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/customer/repository/CustomerRepository.java
@@ -23,4 +23,9 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
     @Modifying
     @Query("UPDATE Customer c SET c.accountBalance = c.accountBalance - :amount WHERE c.customerId = :customerId AND c.accountBalance >= :amount")
     int decreaseBalance(@Param("customerId") Long customerId, @Param("amount") int amount);
+
+    @Modifying
+    @Query("UPDATE Customer c SET c.accountBalance = c.accountBalance + :amount WHERE c.customerId = :customerId")
+    int increaseBalance(@Param("customerId") Long customerId, @Param("amount") int amount);
+
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/customer/service/implement/CustomerServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/customer/service/implement/CustomerServiceImpl.java
@@ -275,7 +275,7 @@ public class CustomerServiceImpl implements CustomerService {
                             .subTokenAmount(subscription.getSubTokenAmount())
                             .subTokenPrice(price.getEstateTokenPrice() * subscription.getSubTokenAmount())
                             .subDate(subscription.getSubDate())
-                            .subStatus(subscription.getEstate().getSubState())
+                            .subStatus(subscription.getEstate().getEstateStatus())
                             .build();
                 })
                 .toList();

--- a/woorepie/src/main/java/com/piehouse/woorepie/customer/service/implement/CustomerServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/customer/service/implement/CustomerServiceImpl.java
@@ -275,7 +275,7 @@ public class CustomerServiceImpl implements CustomerService {
                             .subTokenAmount(subscription.getSubTokenAmount())
                             .subTokenPrice(price.getEstateTokenPrice() * subscription.getSubTokenAmount())
                             .subDate(subscription.getSubDate())
-                            .subStatus(subscription.getEstate().getEstateStatus())
+                            .subStatus(subscription.getSubStatus())
                             .build();
                 })
                 .toList();

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/entity/Estate.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/entity/Estate.java
@@ -91,7 +91,7 @@ public class Estate {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private SubState subState = SubState.READY;
+    private EstateStatus estateStatus = EstateStatus.READY;
 
     // 매물 정보 수정
     public Estate updateDescription(String newDescription) {
@@ -100,11 +100,11 @@ public class Estate {
     }
 
     public void updateSubStateToSuccess() {
-        this.subState = SubState.SUCCESS;
+        this.estateStatus = EstateStatus.SUCCESS;
     }
 
     public void updateSubStateToExit() {
-        this.subState = SubState.EXIT;
+        this.estateStatus = EstateStatus.EXIT;
     }
 
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/entity/Estate.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/entity/Estate.java
@@ -96,11 +96,11 @@ public class Estate {
         return this;
     }
 
-    public void updateSubStateToSuccess() {
+    public void updateEstateStatusToSuccess() {
         this.estateStatus = EstateStatus.SUCCESS;
     }
 
-    public void updateSubStateToExit() {
+    public void updateEstateStatusToExit() {
         this.estateStatus = EstateStatus.EXIT;
     }
 

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/entity/Estate.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/entity/Estate.java
@@ -58,9 +58,6 @@ public class Estate {
     @Column(length = 1000)
     private String estateImageUrl;
 
-    @Column(unique = true, length = 200)
-    private String tokenAddress;
-
     @Column(nullable = false, length = 1000)
     private String subGuideUrl;
 

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/entity/EstateStatus.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/entity/EstateStatus.java
@@ -1,6 +1,6 @@
 package com.piehouse.woorepie.estate.entity;
 
-public enum SubState {
+public enum EstateStatus {
     READY, // 청약 등록 대기
     RUNNING, // 청약 중
     PENDING, // 청약 완료 (승인 대기)

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/repository/EstateRepository.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/repository/EstateRepository.java
@@ -13,8 +13,8 @@ public interface EstateRepository extends JpaRepository<Estate, Long> {
     
     Optional<Integer> findTokenAmountByEstateId(Long estateId);
     
-    List<Estate> findBySubState(EstateStatus estateStatus);
+    List<Estate> findByEstateStatus(EstateStatus estateStatus);
 
-    List<Estate> findBySubStateIn(List<EstateStatus> estateStatuses);
+    List<Estate> findByEstateStatusIn(List<EstateStatus> estateStatuses);
 
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/repository/EstateRepository.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/repository/EstateRepository.java
@@ -1,7 +1,7 @@
 package com.piehouse.woorepie.estate.repository;
 
 import com.piehouse.woorepie.estate.entity.Estate;
-import com.piehouse.woorepie.estate.entity.SubState;
+import com.piehouse.woorepie.estate.entity.EstateStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,8 +13,8 @@ public interface EstateRepository extends JpaRepository<Estate, Long> {
     
     Optional<Integer> findTokenAmountByEstateId(Long estateId);
     
-    List<Estate> findBySubState(SubState subState);
+    List<Estate> findBySubState(EstateStatus estateStatus);
 
-    List<Estate> findBySubStateIn(List<SubState> subStates);
+    List<Estate> findBySubStateIn(List<EstateStatus> estateStatuses);
 
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/service/implement/EstateServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/service/implement/EstateServiceImpl.java
@@ -34,7 +34,7 @@ public class EstateServiceImpl implements EstateService {
     @Transactional(readOnly = true)
     public List<GetEstateSimpleResponse> getTradableEstates() {
 
-        List<Estate> estates = estateRepository.findBySubState(EstateStatus.SUCCESS);
+        List<Estate> estates = estateRepository.findByEstateStatus(EstateStatus.SUCCESS);
 
         List<Long> estateIds = estates.stream()
                 .map(Estate::getEstateId)

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/service/implement/EstateServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/service/implement/EstateServiceImpl.java
@@ -7,14 +7,13 @@ import com.piehouse.woorepie.estate.dto.response.GetEstatePriceResponse;
 import com.piehouse.woorepie.estate.dto.response.GetEstateSimpleResponse;
 import com.piehouse.woorepie.estate.entity.Estate;
 import com.piehouse.woorepie.estate.entity.EstatePrice;
-import com.piehouse.woorepie.estate.entity.SubState;
+import com.piehouse.woorepie.estate.entity.EstateStatus;
 import com.piehouse.woorepie.estate.repository.EstatePriceRepository;
 import com.piehouse.woorepie.estate.repository.EstateRepository;
 import com.piehouse.woorepie.estate.service.EstateService;
 import com.piehouse.woorepie.global.exception.CustomException;
 import com.piehouse.woorepie.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,7 +34,7 @@ public class EstateServiceImpl implements EstateService {
     @Transactional(readOnly = true)
     public List<GetEstateSimpleResponse> getTradableEstates() {
 
-        List<Estate> estates = estateRepository.findBySubState(SubState.SUCCESS);
+        List<Estate> estates = estateRepository.findBySubState(EstateStatus.SUCCESS);
 
         List<Long> estateIds = estates.stream()
                 .map(Estate::getEstateId)

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/exception/ErrorCode.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/exception/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
     ALREADY_REGISTERED_EMAIL(HttpStatus.BAD_REQUEST, "이미 등록된 이메일입니다."),
     ALREADY_REGISTERED_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 등록된 전화번호입니다."),
     TOKEN_INSUFFICIENT(HttpStatus.BAD_REQUEST, "남은 토큰이 부족합니다."),
+    DUPLICATE_SUBSCRIPTION(HttpStatus.BAD_REQUEST, "이미 청약한 기록이 있습니다."), // 중복 청약
+    ESTATE_NOT_RUNNING(HttpStatus.BAD_REQUEST, "청약 진행 중인 매물이 아닙니다."),
 
     // 401: 인증 실패
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "로그인 정보가 일치하지 않습니다."),

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/dto/SubscriptionAcceptEvent.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/dto/SubscriptionAcceptEvent.java
@@ -1,0 +1,26 @@
+package com.piehouse.woorepie.global.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SubscriptionAcceptEvent {
+    private Long estateId;
+    private List<CustomerInfo> customer;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CustomerInfo {
+        private Long customerId;
+        private Integer tokenPrice;
+        private Integer tradeTokenAmount;
+    }
+}

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/dto/SubscriptionAcceptEvent.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/dto/SubscriptionAcceptEvent.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Builder
 public class SubscriptionAcceptEvent {
     private Long estateId;
+    private Integer tokenPrice;
     private List<CustomerInfo> customer;
 
     @Getter
@@ -20,7 +21,6 @@ public class SubscriptionAcceptEvent {
     @Builder
     public static class CustomerInfo {
         private Long customerId;
-        private Integer tokenPrice;
         private Integer tradeTokenAmount;
     }
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/dto/SubscriptionResultEvent.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/dto/SubscriptionResultEvent.java
@@ -1,0 +1,10 @@
+package com.piehouse.woorepie.global.kafka.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SubscriptionResultEvent {
+    private Long estateId;
+}

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/KafkaConsumerService.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/KafkaConsumerService.java
@@ -8,6 +8,10 @@ public interface KafkaConsumerService {
 
     void consumeSubscriptionRequest(SubscriptionRequestEvent event);
 
+    void consumeSubscriptionSuccess(SubscriptionResultEvent event);
+
+    void consumeSubscriptionFailure(SubscriptionResultEvent event);
+
     void handleSubscriptionApproval(SubscriptionAcceptMessage message);
 
     void handleDividendApproval(DividendAcceptMessage message);

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/KafkaProducerService.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/KafkaProducerService.java
@@ -13,7 +13,7 @@ public interface KafkaProducerService {
 
     void sendCustomerCreated(CustomerCreatedEvent event); // 회원가입 완료 이벤트
 
-    void sendSubscriptionRequest(SubscriptionRequestEvent event);
+    void sendSubscriptionRequest(SubscriptionRequestEvent event); // 청약 신청
 
 
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/KafkaProducerService.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/KafkaProducerService.java
@@ -1,9 +1,6 @@
 package com.piehouse.woorepie.global.kafka.service;
 
-import com.piehouse.woorepie.global.kafka.dto.OrderCreatedEvent;
-import com.piehouse.woorepie.global.kafka.dto.SubscriptionRequestEvent;
-import com.piehouse.woorepie.global.kafka.dto.TransactionCreatedEvent;
-import com.piehouse.woorepie.global.kafka.dto.CustomerCreatedEvent;
+import com.piehouse.woorepie.global.kafka.dto.*;
 
 public interface KafkaProducerService {
 
@@ -13,8 +10,8 @@ public interface KafkaProducerService {
 
     void sendCustomerCreated(CustomerCreatedEvent event); // 회원가입 완료 이벤트
 
-    void sendSubscriptionRequest(SubscriptionRequestEvent event); // 청약 신청
+    void sendSubscriptionRequest(SubscriptionRequestEvent event); // 청약 신청 이벤트
 
-
+    void sendSubscriptionAccept(SubscriptionAcceptEvent event); // 청약 성공 결과 이벤트
 }
 

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/impliment/KafkaConsumerServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/impliment/KafkaConsumerServiceImpl.java
@@ -123,7 +123,7 @@ public class KafkaConsumerServiceImpl implements KafkaConsumerService {
         });
 
         // 매물 상태 변경 → SUCCESS
-        estate.updateSubStateToSuccess();
+        estate.updateEstateStatusToSuccess();
         estateRepository.save(estate);
 
     }
@@ -188,7 +188,7 @@ public class KafkaConsumerServiceImpl implements KafkaConsumerService {
                 .orElseThrow(() -> new CustomException(ErrorCode.ESTATE_NOT_FOUND));
 
         // 2. 상태 EXIT 변경
-        estate.updateSubStateToExit();
+        estate.updateEstateStatusToExit();
         estateRepository.save(estate);
 
         // 3. 최근 시세 조회

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/impliment/KafkaConsumerServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/impliment/KafkaConsumerServiceImpl.java
@@ -59,9 +59,23 @@ public class KafkaConsumerServiceImpl implements KafkaConsumerService {
     @Override
     @KafkaListener(topics = "subscription.request")
     public void consumeSubscriptionRequest(SubscriptionRequestEvent event) {
-        log.info("청약 요청 수신: customerId={}, estateId={}, amount={}, subscribeDate={}",
+        log.info("[Kafka] 청약 요청 수신: customerId={}, estateId={}, amount={}, subscribeDate={}",
                 event.getCustomerId(), event.getEstateId(), event.getAmount(), event.getSubscribeDate());
         tradeService.processSubscriptionRequest(event.getEstateId(), event.getCustomerId(), event.getAmount(), event.getTokenPrice());
+    }
+
+    @Override
+    @KafkaListener(topics = "subscription.success")
+    public void consumeSubscriptionSuccess(SubscriptionResultEvent event) {
+        log.info("[Kafka] 청약 결과 - 모집 완료 수신 : estateId={}", event.getEstateId());
+        // 청약 모집 성공 서비스 로직 추후 추가 예정
+    }
+
+    @Override
+    @KafkaListener(topics = "subscription.failure")
+    public void consumeSubscriptionFailure(SubscriptionResultEvent event) {
+        log.info("[Kafka] 청약 결과 - 모집 실패 수신 : estateId={}", event.getEstateId());
+        // 청약 모집 실패 서비스 로직 추후 추가 예정
     }
 
     @Override

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/impliment/KafkaConsumerServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/impliment/KafkaConsumerServiceImpl.java
@@ -15,6 +15,7 @@ import com.piehouse.woorepie.global.exception.CustomException;
 import com.piehouse.woorepie.global.exception.ErrorCode;
 import com.piehouse.woorepie.global.kafka.dto.*;
 import com.piehouse.woorepie.global.kafka.service.KafkaConsumerService;
+import com.piehouse.woorepie.subscription.service.SubscriptionService;
 import com.piehouse.woorepie.trade.service.TradeRedisService;
 import com.piehouse.woorepie.trade.service.TradeService;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,7 @@ public class KafkaConsumerServiceImpl implements KafkaConsumerService {
 
     private final TradeService tradeService;
     private final TradeRedisService tradeRedisService;
+    private final SubscriptionService subscriptionService;
     private final EstateRedisServiceImpl estateRedisServiceImpl;
     private final EstateRepository estateRepository;
     private final AccountRepository accountRepository;
@@ -68,14 +70,14 @@ public class KafkaConsumerServiceImpl implements KafkaConsumerService {
     @KafkaListener(topics = "subscription.success")
     public void consumeSubscriptionSuccess(SubscriptionResultEvent event) {
         log.info("[Kafka] 청약 결과 - 모집 완료 수신 : estateId={}", event.getEstateId());
-        // 청약 모집 성공 서비스 로직 추후 추가 예정
+        subscriptionService.updateSubscriptionsOnSuccess(event.getEstateId());
     }
 
     @Override
     @KafkaListener(topics = "subscription.failure")
     public void consumeSubscriptionFailure(SubscriptionResultEvent event) {
         log.info("[Kafka] 청약 결과 - 모집 실패 수신 : estateId={}", event.getEstateId());
-        // 청약 모집 실패 서비스 로직 추후 추가 예정
+        subscriptionService.updateSubscriptionsOnFailure(event.getEstateId());
     }
 
     @Override

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/impliment/KafkaConsumerServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/impliment/KafkaConsumerServiceImpl.java
@@ -16,6 +16,7 @@ import com.piehouse.woorepie.global.exception.ErrorCode;
 import com.piehouse.woorepie.global.kafka.dto.*;
 import com.piehouse.woorepie.global.kafka.service.KafkaConsumerService;
 import com.piehouse.woorepie.trade.service.TradeRedisService;
+import com.piehouse.woorepie.trade.service.TradeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -32,6 +33,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class KafkaConsumerServiceImpl implements KafkaConsumerService {
 
+    private final TradeService tradeService;
     private final TradeRedisService tradeRedisService;
     private final EstateRedisServiceImpl estateRedisServiceImpl;
     private final EstateRepository estateRepository;
@@ -59,7 +61,7 @@ public class KafkaConsumerServiceImpl implements KafkaConsumerService {
     public void consumeSubscriptionRequest(SubscriptionRequestEvent event) {
         log.info("청약 요청 수신: customerId={}, estateId={}, amount={}, subscribeDate={}",
                 event.getCustomerId(), event.getEstateId(), event.getAmount(), event.getSubscribeDate());
-        // 토큰 체크 및 결과 처리)은 이후에 구현
+        tradeService.processSubscriptionRequest(event.getEstateId(), event.getCustomerId(), event.getAmount(), event.getTokenPrice());
     }
 
     @Override

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/impliment/KafkaProducerServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/impliment/KafkaProducerServiceImpl.java
@@ -1,9 +1,6 @@
 package com.piehouse.woorepie.global.kafka.service.impliment;
 
-import com.piehouse.woorepie.global.kafka.dto.CustomerCreatedEvent;
-import com.piehouse.woorepie.global.kafka.dto.SubscriptionRequestEvent;
-import com.piehouse.woorepie.global.kafka.dto.TransactionCreatedEvent;
-import com.piehouse.woorepie.global.kafka.dto.OrderCreatedEvent;
+import com.piehouse.woorepie.global.kafka.dto.*;
 import com.piehouse.woorepie.global.kafka.service.KafkaProducerService;
 import com.piehouse.woorepie.global.util.KafkaRetryUtil;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +19,7 @@ public class KafkaProducerServiceImpl implements KafkaProducerService {
     private static final String TRANSACTION_CREATED_TOPIC = "transaction.created";
     private static final String CUSTOMER_CREATED_TOPIC = "customer.created";
     private static final String SUBSCRIPTION_REQUEST_TOPIC = "subscription.request";
+    private static final String SUBSCRIPTION_ACCEPT_TOPIC = "subscription.accept";
 
     // Kafka에 매수, 매도 요청 이벤트 보내기
     @Override
@@ -45,6 +43,12 @@ public class KafkaProducerServiceImpl implements KafkaProducerService {
     @Override
     public void sendSubscriptionRequest(SubscriptionRequestEvent event) {
         sendWithKey(SUBSCRIPTION_REQUEST_TOPIC, event.getEstateId().toString(), event); // 공통 send() 사용
+    }
+
+    // kafka에 청약 성공 결과 이벤트 보내기
+    @Override
+    public void sendSubscriptionAccept(SubscriptionAcceptEvent event) {
+        send(SUBSCRIPTION_ACCEPT_TOPIC, event);
     }
 
     private <T> void send(String topic, T event) {

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/dto/response/GetSubscriptionDetailsResponse.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/dto/response/GetSubscriptionDetailsResponse.java
@@ -1,6 +1,6 @@
 package com.piehouse.woorepie.subscription.dto.response;
 
-import com.piehouse.woorepie.estate.entity.SubState;
+import com.piehouse.woorepie.estate.entity.EstateStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -49,7 +49,7 @@ public class GetSubscriptionDetailsResponse {
 
     private Integer estateTokenPrice;
 
-    private SubState subState;
+    private EstateStatus estateStatus;
 
     private String estateUseZone;
 

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/dto/response/GetSubscriptionSimpleResponse.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/dto/response/GetSubscriptionSimpleResponse.java
@@ -1,6 +1,6 @@
 package com.piehouse.woorepie.subscription.dto.response;
 
-import com.piehouse.woorepie.estate.entity.SubState;
+import com.piehouse.woorepie.estate.entity.EstateStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,6 +39,6 @@ public class GetSubscriptionSimpleResponse {
 
     private BigDecimal dividendYield;
 
-    private SubState subState;
+    private EstateStatus estateStatus;
 
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/dto/response/GetSubscriptionSimpleResponse.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/dto/response/GetSubscriptionSimpleResponse.java
@@ -39,6 +39,6 @@ public class GetSubscriptionSimpleResponse {
 
     private BigDecimal dividendYield;
 
-    private EstateStatus estateStatus;
+    private EstateStatus subState;
 
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/entity/SubStatus.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/entity/SubStatus.java
@@ -1,0 +1,7 @@
+package com.piehouse.woorepie.subscription.entity;
+
+public enum SubStatus {
+    SUCCESS,
+    PENDING,
+    FAILURE
+}

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/entity/Subscription.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/entity/Subscription.java
@@ -9,7 +9,13 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "subscription")
+@Table(
+        name = "subscription",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_customer_estate_date",
+                columnNames = {"customer_id", "estate_id", "sub_date"}
+        )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/entity/Subscription.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/entity/Subscription.java
@@ -2,6 +2,7 @@ package com.piehouse.woorepie.subscription.entity;
 
 import com.piehouse.woorepie.customer.entity.Customer;
 import com.piehouse.woorepie.estate.entity.Estate;
+import com.piehouse.woorepie.estate.entity.EstateStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -44,4 +45,7 @@ public class Subscription {
     @Column(updatable = false)
     private LocalDateTime subDate;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sub_status", nullable = false)
+    private SubStatus subStatus = SubStatus.PENDING;
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/entity/Subscription.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/entity/Subscription.java
@@ -48,4 +48,15 @@ public class Subscription {
     @Enumerated(EnumType.STRING)
     @Column(name = "sub_status", nullable = false)
     private SubStatus subStatus = SubStatus.PENDING;
+
+    // 상태 변경 메소드 추가
+    public void changeStatus(SubStatus newStatus) {
+        this.subStatus = newStatus;
+    }
+
+    // 토큰 수량 업데이트 메소드 추가
+    public void changeSubTokenAmount(int newAmount) {
+        this.subTokenAmount = newAmount;
+    }
+
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/entity/Subscription.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/entity/Subscription.java
@@ -10,13 +10,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(
-        name = "subscription",
-        uniqueConstraints = @UniqueConstraint(
-                name = "uk_customer_estate_date",
-                columnNames = {"customer_id", "estate_id", "sub_date"}
-        )
-)
+@Table(name = "subscription")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/repository/SubscriptionRepository.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/repository/SubscriptionRepository.java
@@ -2,13 +2,19 @@ package com.piehouse.woorepie.subscription.repository;
 
 import com.piehouse.woorepie.subscription.entity.Subscription;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
 
 //    List<Subscription> findBySubState(short subState);
 
     List<Subscription> findByCustomer_CustomerId(Long customerId);
 
+    @Query("SELECT COALESCE(SUM(s.subTokenAmount), 0) FROM Subscription s WHERE s.estate.estateId = :estateId")
+    int sumSubTokenAmountByEstateId(@Param("estateId") Long estateId);
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/repository/SubscriptionRepository.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/repository/SubscriptionRepository.java
@@ -22,4 +22,7 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
 
     // 해당 매물의 특정 상태 청약 내역을 신청일 기준 오름차순 조회
     List<Subscription> findAllByEstate_EstateIdAndSubStatusOrderBySubDateAsc(Long estateId, SubStatus subStatus);
+
+    // 해당 매물의 특정 상태 청약 내역 전체 조회
+    List<Subscription> findAllByEstate_EstateIdAndSubStatus(Long estateId, SubStatus subStatus);
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/repository/SubscriptionRepository.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/repository/SubscriptionRepository.java
@@ -1,5 +1,6 @@
 package com.piehouse.woorepie.subscription.repository;
 
+import com.piehouse.woorepie.subscription.entity.SubStatus;
 import com.piehouse.woorepie.subscription.entity.Subscription;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,7 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
 
     @Query("SELECT COALESCE(SUM(s.subTokenAmount), 0) FROM Subscription s WHERE s.estate.estateId = :estateId")
     int sumSubTokenAmountByEstateId(@Param("estateId") Long estateId);
+
+    // 해당 매물의 특정 상태 청약 내역을 신청일 기준 오름차순 조회
+    List<Subscription> findAllByEstate_EstateIdAndSubStatusOrderBySubDateAsc(Long estateId, SubStatus subStatus);
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/scheduler/SubscriptionSyncScheduler.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/scheduler/SubscriptionSyncScheduler.java
@@ -1,0 +1,53 @@
+package com.piehouse.woorepie.subscription.scheduler;
+
+import com.piehouse.woorepie.estate.entity.Estate;
+import com.piehouse.woorepie.estate.entity.SubState;
+import com.piehouse.woorepie.estate.repository.EstateRepository;
+import com.piehouse.woorepie.subscription.repository.SubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SubscriptionSyncScheduler {
+    private final EstateRepository estateRepository;
+    private final SubscriptionRepository subscriptionRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시 실행
+    public void validateTokenConsistency() {
+        // 1. 진행 중인(subState=RUNNING) 매물만 조회
+        List<Estate> runningEstates = estateRepository.findBySubState(SubState.RUNNING);
+
+        runningEstates.forEach(estate -> {
+            String redisKey = String.format("subscription:%s:remaining-tokens", estate.getEstateId());
+            String redisValue = redisTemplate.opsForValue().get(redisKey);
+
+            if (redisValue == null) {
+                log.warn("Redis 키 없음 - estateId: {}", estate.getEstateId());
+                return;
+            }
+
+            int redisRemaining = Integer.parseInt(redisValue);
+            int totalSubscribed = subscriptionRepository.sumSubTokenAmountByEstateId(estate.getEstateId());
+            int totalTokens = estate.getTokenAmount(); // tokenAmount 필드 사용
+
+            if (redisRemaining != (totalTokens - totalSubscribed)) {
+                log.error("토큰 불일치 - estateId: {}, Redis: {}, PostgreSQL 계산: {}",
+                        estate.getEstateId(), redisRemaining, (totalTokens - totalSubscribed));
+
+                // 자동 보정
+                redisTemplate.opsForValue().set(
+                        redisKey,
+                        String.valueOf(totalTokens - totalSubscribed)
+                );
+            }
+        });
+    }
+}

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/scheduler/SubscriptionSyncScheduler.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/scheduler/SubscriptionSyncScheduler.java
@@ -23,7 +23,7 @@ public class SubscriptionSyncScheduler {
     @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시 실행
     public void validateTokenConsistency() {
         // 1. 진행 중인(subState=RUNNING) 매물만 조회
-        List<Estate> runningEstates = estateRepository.findBySubState(EstateStatus.RUNNING);
+        List<Estate> runningEstates = estateRepository.findByEstateStatus(EstateStatus.RUNNING);
 
         runningEstates.forEach(estate -> {
             String redisKey = String.format("subscription:%s:remaining-tokens", estate.getEstateId());

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/scheduler/SubscriptionSyncScheduler.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/scheduler/SubscriptionSyncScheduler.java
@@ -1,7 +1,7 @@
 package com.piehouse.woorepie.subscription.scheduler;
 
 import com.piehouse.woorepie.estate.entity.Estate;
-import com.piehouse.woorepie.estate.entity.SubState;
+import com.piehouse.woorepie.estate.entity.EstateStatus;
 import com.piehouse.woorepie.estate.repository.EstateRepository;
 import com.piehouse.woorepie.subscription.repository.SubscriptionRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +23,7 @@ public class SubscriptionSyncScheduler {
     @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시 실행
     public void validateTokenConsistency() {
         // 1. 진행 중인(subState=RUNNING) 매물만 조회
-        List<Estate> runningEstates = estateRepository.findBySubState(SubState.RUNNING);
+        List<Estate> runningEstates = estateRepository.findBySubState(EstateStatus.RUNNING);
 
         runningEstates.forEach(estate -> {
             String redisKey = String.format("subscription:%s:remaining-tokens", estate.getEstateId());

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/SubscriptionService.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/SubscriptionService.java
@@ -16,6 +16,9 @@ public interface SubscriptionService {
     //청약 매물 상세정보 조회
     GetSubscriptionDetailsResponse getSubscriptionDetails(Long estateId);
 
-    // 청약 결과 DB에 업데이트
-    void updateSubscriptionStatus(Long estateId);
+    // 청약 모집 완료에 따른 처리
+    void updateSubscriptionsOnSuccess(Long estateId);
+
+    // 청약 모집 실패에 따른 처리
+    void updateSubscriptionsOnFailure(Long estateId);
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/SubscriptionService.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/SubscriptionService.java
@@ -16,4 +16,6 @@ public interface SubscriptionService {
     //청약 매물 상세정보 조회
     GetSubscriptionDetailsResponse getSubscriptionDetails(Long estateId);
 
+    // 청약 결과 DB에 업데이트
+    void updateSubscriptionStatus(Long estateId);
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
@@ -272,7 +272,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     public void updateSubscriptionsOnFailure(Long estateId) {
         // 1. 전체 pending 청약 내역 조회
         List<Subscription> pendingSubs = subscriptionRepository
-                .findAllByEstate_EstateIdAndSubStatusOrderBySubDateAsc(estateId, SubStatus.PENDING);
+                .findAllByEstate_EstateIdAndSubStatus(estateId, SubStatus.PENDING);
 
         // 2. 토큰당 가격 조회
         RedisEstatePrice redisPrice = estateRedisService.getRedisEstatePrice(estateId);

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
@@ -121,7 +121,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                             .estatePrice(price.getEstatePrice())
                             .estateTokenPrice(price.getEstateTokenPrice())
                             .dividendYield(price.getDividendYield())
-                            .estateStatus(estate.getEstateStatus())
+                            .subState(estate.getEstateStatus())
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
@@ -2,6 +2,7 @@ package com.piehouse.woorepie.subscription.service.implement;
 
 import com.piehouse.woorepie.agent.entity.Agent;
 import com.piehouse.woorepie.agent.repository.AgentRepository;
+import com.piehouse.woorepie.customer.repository.CustomerRepository;
 import com.piehouse.woorepie.estate.dto.RedisEstatePrice;
 import com.piehouse.woorepie.estate.entity.Estate;
 import com.piehouse.woorepie.estate.entity.EstatePrice;
@@ -27,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -43,6 +45,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     private final SubscriptionRepository subscriptionRepository;
     private final KafkaProducerService kafkaProducerService;
     private final EstateRedisService estateRedisService;
+    private final CustomerRepository customerRepository;
 
     @Override
     @Transactional
@@ -172,35 +175,39 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     @Override
     @Transactional
     public void updateSubscriptionStatus(Long estateId) {
-        // 1. 모집 성공 대상 estateId의 pending 청약 내역 모두 조회
+        // 1. pending 상태 청약 내역 모두 조회 (신청일순 정렬)
         List<Subscription> pendingSubs = subscriptionRepository
                 .findAllByEstate_EstateIdAndSubStatusOrderBySubDateAsc(estateId, SubStatus.PENDING);
 
-        // 2. 모집 가능 토큰 수량 확인
+        // 2. 모집 대상 매물, 토큰 단가 조회
         Estate estate = estateRepository.findById(estateId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ESTATE_NOT_FOUND));
+
+        // Redis에서 1토큰당 가격 조회
+        RedisEstatePrice redisPrice = estateRedisService.getRedisEstatePrice(estateId);
+        int tokenPrice = redisPrice.getEstateTokenPrice();
 
         int availableToken = estate.getTokenAmount();
 
         int allocated = 0;
         Subscription partialFailureRow = null; // 부분 성공자(일부 성공, 일부 실패)
+        List<Subscription> failureSubs = new ArrayList<>(); // 실패자 환불용 리스트
 
+        // 3. 선착순 배정 및 성공/실패/부분실패 처리
         for (Subscription sub : pendingSubs) {
             int remain = availableToken - allocated;
             int reqAmount = sub.getSubTokenAmount();
 
-            if (remain <= 0) {
-                // 전체 실패: 기존 row만 update
+            if (remain <= 0) { // 전부 실패
                 sub.changeStatus(SubStatus.FAILURE);
+                failureSubs.add(sub);
                 continue;
             }
 
-            if (reqAmount <= remain) {
-                // 전체 성공: 기존 row만 update
+            if (reqAmount <= remain) { // 전부 성공
                 sub.changeStatus(SubStatus.SUCCESS);
                 allocated += reqAmount;
-            } else {
-                // 부분 성공: (이 루프에서 단 1회만 발생)
+            } else { // 부분 성공(한 명만 발생 가능)
                 sub.changeStatus(SubStatus.SUCCESS);
                 sub.changeSubTokenAmount(remain);
                 allocated += remain;
@@ -216,33 +223,31 @@ public class SubscriptionServiceImpl implements SubscriptionService {
             }
         }
 
-        // 3. 부분 실패자가 있으면 실패한 row 저장
+        // 4. 부분 실패자 row 저장/환불 대상 추가
         if (partialFailureRow != null) {
             subscriptionRepository.save(partialFailureRow);
+            failureSubs.add(partialFailureRow);
         }
 
-        // 4. 일괄 저장 (변경된 엔티티를 DB에 update)
+        // 5. DB에 상태 일괄 저장
         subscriptionRepository.saveAll(pendingSubs);
 
-        // 5. 성공자 Kafka accept 이벤트 전송
+        // 6. 성공자에 대해 Kafka accept 이벤트 발송
         List<Subscription> successSubs = pendingSubs.stream()
                 .filter(sub -> sub.getSubStatus() == SubStatus.SUCCESS)
                 .toList();
 
-        sendKafkaAcceptEvent(successSubs, estateId);
+        sendKafkaAcceptEvent(successSubs, estateId, tokenPrice);
 
-        // 6. 실패자 환불, 알림 등 후처리
-
+        // 7. 실패자 환불 처리
+        for (Subscription failSub : failureSubs) {
+            refundSubscriptionFailure(failSub, tokenPrice);
+        }
     }
 
-    // 성공자 Kafka accept 이벤트 전송
-    private void sendKafkaAcceptEvent(List<Subscription> successSubs, Long estateId) {
-        if (successSubs.isEmpty()) {
-            return; // 성공자가 없으면 이벤트 전송 생략
-        }
-
-        RedisEstatePrice redisPrice = estateRedisService.getRedisEstatePrice(estateId);
-        int tokenPrice = redisPrice.getEstateTokenPrice();
+    // 성공자에 대해 Kafka accept 이벤트 발송
+    private void sendKafkaAcceptEvent(List<Subscription> successSubs, Long estateId, int tokenPrice) {
+        if (successSubs.isEmpty()) return;
 
         List<SubscriptionAcceptEvent.CustomerInfo> customerList = successSubs.stream()
                 .map(sub -> new SubscriptionAcceptEvent.CustomerInfo(
@@ -258,5 +263,14 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                 .build();
 
         kafkaProducerService.sendSubscriptionAccept(event);
+    }
+
+    // 환불 처리 메소드
+    public void refundSubscriptionFailure(Subscription failSub, int tokenPrice) {
+        int refundAmount = failSub.getSubTokenAmount() * tokenPrice;
+        int updatedRows = customerRepository.increaseBalance(failSub.getCustomer().getCustomerId(), refundAmount);
+        if (updatedRows == 0) {
+            throw new CustomException(ErrorCode.ACCOUNT_NON_EXIST);
+        }
     }
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
@@ -92,7 +92,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     @Transactional(readOnly = true)
     public List<GetSubscriptionSimpleResponse> getActiveSubscriptions() {
 
-        List<Estate> estates = estateRepository.findBySubStateIn(List.of(
+        List<Estate> estates = estateRepository.findByEstateStatusIn(List.of(
                 EstateStatus.READY, EstateStatus.RUNNING, EstateStatus.PENDING, EstateStatus.FAILURE
         )); // 청약 중인 substate 필터링
 

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
@@ -5,7 +5,7 @@ import com.piehouse.woorepie.agent.repository.AgentRepository;
 import com.piehouse.woorepie.estate.dto.RedisEstatePrice;
 import com.piehouse.woorepie.estate.entity.Estate;
 import com.piehouse.woorepie.estate.entity.EstatePrice;
-import com.piehouse.woorepie.estate.entity.SubState;
+import com.piehouse.woorepie.estate.entity.EstateStatus;
 import com.piehouse.woorepie.estate.repository.EstatePriceRepository;
 import com.piehouse.woorepie.estate.repository.EstateRepository;
 import com.piehouse.woorepie.estate.service.implement.EstateRedisServiceImpl;
@@ -61,7 +61,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                 .appraisalReportUrl(s3serviceImpl.getPublicS3Url(request.getAppraisalReportUrlKey()))
                 .estateRegistrationDate(LocalDateTime.now())
                 .tokenAmount(request.getTokenAmount())
-                .subState(SubState.READY)
+                .estateStatus(EstateStatus.READY)
                 .build();
         estateRepository.save(estate);
 
@@ -81,7 +81,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     public List<GetSubscriptionSimpleResponse> getActiveSubscriptions() {
 
         List<Estate> estates = estateRepository.findBySubStateIn(List.of(
-                SubState.READY, SubState.RUNNING, SubState.PENDING, SubState.FAILURE
+                EstateStatus.READY, EstateStatus.RUNNING, EstateStatus.PENDING, EstateStatus.FAILURE
         )); // 청약 중인 substate 필터링
 
         List<Long> estateIds = estates.stream()
@@ -109,7 +109,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                             .estatePrice(price.getEstatePrice())
                             .estateTokenPrice(price.getEstateTokenPrice())
                             .dividendYield(price.getDividendYield())
-                            .subState(estate.getSubState())
+                            .estateStatus(estate.getEstateStatus())
                             .build();
                 })
                 .collect(Collectors.toList());
@@ -147,7 +147,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                 .subTokenAmount(subTokenAmount)
                 .estateTokenPrice(price.getEstateTokenPrice())
                 .dividendYield(price.getDividendYield())
-                .subState(estate.getSubState())
+                .estateStatus(estate.getEstateStatus())
                 .estateUseZone(estate.getEstateUseZone())
                 .totalEstateArea(estate.getTotalEstateArea())
                 .tradedEstateArea(estate.getTradedEstateArea())

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
@@ -172,9 +172,10 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
     }
 
+    // 청약 모집 성공 : 선착순 배정
     @Override
     @Transactional
-    public void updateSubscriptionStatus(Long estateId) {
+    public void updateSubscriptionsOnSuccess(Long estateId) {
         // 1. pending 상태 청약 내역 모두 조회 (신청일순 정렬)
         List<Subscription> pendingSubs = subscriptionRepository
                 .findAllByEstate_EstateIdAndSubStatusOrderBySubDateAsc(estateId, SubStatus.PENDING);
@@ -263,6 +264,26 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                 .build();
 
         kafkaProducerService.sendSubscriptionAccept(event);
+    }
+
+    // 청약 모집 실패 : 전체 실패 처리 및 일괄 환불
+    @Override
+    @Transactional
+    public void updateSubscriptionsOnFailure(Long estateId) {
+        // 1. 전체 pending 청약 내역 조회
+        List<Subscription> pendingSubs = subscriptionRepository
+                .findAllByEstate_EstateIdAndSubStatusOrderBySubDateAsc(estateId, SubStatus.PENDING);
+
+        // 2. 토큰당 가격 조회
+        RedisEstatePrice redisPrice = estateRedisService.getRedisEstatePrice(estateId);
+        int tokenPrice = redisPrice.getEstateTokenPrice();
+
+        // 3. 모두 FAILURE 처리 + 일괄 저장
+        pendingSubs.forEach(sub -> sub.changeStatus(SubStatus.FAILURE));
+        subscriptionRepository.saveAll(pendingSubs);
+
+        // 4. 일괄 환불
+        pendingSubs.forEach(sub -> refundSubscriptionFailure(sub, tokenPrice));
     }
 
     // 환불 처리 메소드

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
@@ -8,13 +8,19 @@ import com.piehouse.woorepie.estate.entity.EstatePrice;
 import com.piehouse.woorepie.estate.entity.EstateStatus;
 import com.piehouse.woorepie.estate.repository.EstatePriceRepository;
 import com.piehouse.woorepie.estate.repository.EstateRepository;
+import com.piehouse.woorepie.estate.service.EstateRedisService;
 import com.piehouse.woorepie.estate.service.implement.EstateRedisServiceImpl;
 import com.piehouse.woorepie.global.exception.CustomException;
 import com.piehouse.woorepie.global.exception.ErrorCode;
+import com.piehouse.woorepie.global.kafka.dto.SubscriptionAcceptEvent;
+import com.piehouse.woorepie.global.kafka.service.KafkaProducerService;
 import com.piehouse.woorepie.global.service.implement.S3ServiceImpl;
 import com.piehouse.woorepie.subscription.dto.request.RegisterEstateRequest;
 import com.piehouse.woorepie.subscription.dto.response.GetSubscriptionDetailsResponse;
 import com.piehouse.woorepie.subscription.dto.response.GetSubscriptionSimpleResponse;
+import com.piehouse.woorepie.subscription.entity.SubStatus;
+import com.piehouse.woorepie.subscription.entity.Subscription;
+import com.piehouse.woorepie.subscription.repository.SubscriptionRepository;
 import com.piehouse.woorepie.subscription.service.SubscriptionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,6 +40,9 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     private final AgentRepository agentRepository;
     private final EstateRedisServiceImpl  estateRedisServiceImpl;
     private final S3ServiceImpl s3serviceImpl;
+    private final SubscriptionRepository subscriptionRepository;
+    private final KafkaProducerService kafkaProducerService;
+    private final EstateRedisService estateRedisService;
 
     @Override
     @Transactional
@@ -160,4 +169,94 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
     }
 
+    @Override
+    @Transactional
+    public void updateSubscriptionStatus(Long estateId) {
+        // 1. 모집 성공 대상 estateId의 pending 청약 내역 모두 조회
+        List<Subscription> pendingSubs = subscriptionRepository
+                .findAllByEstate_EstateIdAndSubStatusOrderBySubDateAsc(estateId, SubStatus.PENDING);
+
+        // 2. 모집 가능 토큰 수량 확인
+        Estate estate = estateRepository.findById(estateId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ESTATE_NOT_FOUND));
+
+        int availableToken = estate.getTokenAmount();
+
+        int allocated = 0;
+        Subscription partialFailureRow = null; // 부분 성공자(일부 성공, 일부 실패)
+
+        for (Subscription sub : pendingSubs) {
+            int remain = availableToken - allocated;
+            int reqAmount = sub.getSubTokenAmount();
+
+            if (remain <= 0) {
+                // 전체 실패: 기존 row만 update
+                sub.changeStatus(SubStatus.FAILURE);
+                continue;
+            }
+
+            if (reqAmount <= remain) {
+                // 전체 성공: 기존 row만 update
+                sub.changeStatus(SubStatus.SUCCESS);
+                allocated += reqAmount;
+            } else {
+                // 부분 성공: (이 루프에서 단 1회만 발생)
+                sub.changeStatus(SubStatus.SUCCESS);
+                sub.changeSubTokenAmount(remain);
+                allocated += remain;
+
+                // 나머지 실패 부분은 새로 row 생성
+                partialFailureRow = Subscription.builder()
+                        .estate(sub.getEstate())
+                        .customer(sub.getCustomer())
+                        .subTokenAmount(reqAmount - remain)
+                        .subDate(sub.getSubDate())
+                        .subStatus(SubStatus.FAILURE)
+                        .build();
+            }
+        }
+
+        // 3. 부분 실패자가 있으면 실패한 row 저장
+        if (partialFailureRow != null) {
+            subscriptionRepository.save(partialFailureRow);
+        }
+
+        // 4. 일괄 저장 (변경된 엔티티를 DB에 update)
+        subscriptionRepository.saveAll(pendingSubs);
+
+        // 5. 성공자 Kafka accept 이벤트 전송
+        List<Subscription> successSubs = pendingSubs.stream()
+                .filter(sub -> sub.getSubStatus() == SubStatus.SUCCESS)
+                .toList();
+
+        sendKafkaAcceptEvent(successSubs, estateId);
+
+        // 6. 실패자 환불, 알림 등 후처리
+
+    }
+
+    // 성공자 Kafka accept 이벤트 전송
+    private void sendKafkaAcceptEvent(List<Subscription> successSubs, Long estateId) {
+        if (successSubs.isEmpty()) {
+            return; // 성공자가 없으면 이벤트 전송 생략
+        }
+
+        RedisEstatePrice redisPrice = estateRedisService.getRedisEstatePrice(estateId);
+        int tokenPrice = redisPrice.getEstateTokenPrice();
+
+        List<SubscriptionAcceptEvent.CustomerInfo> customerList = successSubs.stream()
+                .map(sub -> new SubscriptionAcceptEvent.CustomerInfo(
+                        sub.getCustomer().getCustomerId(),
+                        sub.getSubTokenAmount()
+                ))
+                .toList();
+
+        SubscriptionAcceptEvent event = SubscriptionAcceptEvent.builder()
+                .estateId(estateId)
+                .tokenPrice(tokenPrice)
+                .customer(customerList)
+                .build();
+
+        kafkaProducerService.sendSubscriptionAccept(event);
+    }
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/trade/repository/RedisTradeRepository.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/trade/repository/RedisTradeRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -87,14 +88,41 @@ public class RedisTradeRepository {
 
     // 고객별 매수 주문 조회 (시간순)
     public Set<RedisCustomerTradeValue> getCustomerBuyOrders(Long customerId) {
+        // 😎 변경됨! (타입 문제 방지: string으로 받고 objectmapper로 변환)
         String key = String.format(CUSTOMER_BUY_KEY, customerId);
-        return redisCustomerTradeTemplate.opsForZSet().rangeByScore(key, 0, Double.MAX_VALUE);
+        Set<String> jsonSet = redisStringTemplate.opsForZSet().range(key, 0, -1);
+
+        if (jsonSet == null) return Set.of();
+
+        return jsonSet.stream()
+                .filter(s -> s != null && !s.isEmpty())
+                .map(json -> {
+                    try {
+                        return objectMapper.readValue(json, RedisCustomerTradeValue.class); // DTO 변환
+                    } catch (Exception e) {
+                        throw new RuntimeException("역직렬화 실패: " + json, e);
+                    }
+                })
+                .collect(Collectors.toSet());
     }
 
     // 고객별 매도 주문 조회 (시간순)
     public Set<RedisCustomerTradeValue> getCustomerSellOrders(Long customerId) {
         String key = String.format(CUSTOMER_SELL_KEY, customerId);
-        return redisCustomerTradeTemplate.opsForZSet().rangeByScore(key, 0, Double.MAX_VALUE);
+        Set<String> jsonSet = redisStringTemplate.opsForZSet().range(key, 0, -1);
+
+        if (jsonSet == null) return Set.of();
+
+        return jsonSet.stream()
+                .filter(s -> s != null && !s.isEmpty())
+                .map(json -> {
+                    try {
+                        return objectMapper.readValue(json, RedisCustomerTradeValue.class); // DTO 변환
+                    } catch (Exception e) {
+                        throw new RuntimeException("역직렬화 실패: " + json, e);
+                    }
+                })
+                .collect(Collectors.toSet());
     }
 
     // 매수 주문 Pop (Lua 스크립트 사용)
@@ -127,7 +155,7 @@ public class RedisTradeRepository {
     private RedisEstateTradeValue deserializeOrder(String json) {
         if (json == null) return null;
         try {
-            return new ObjectMapper().readValue(json, RedisEstateTradeValue.class);
+            return objectMapper.readValue(json, RedisEstateTradeValue.class);
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Failed to deserialize order", e);
         }

--- a/woorepie/src/main/java/com/piehouse/woorepie/trade/service/TradeService.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/trade/service/TradeService.java
@@ -17,4 +17,5 @@ public interface TradeService {
 
     void createSubscription(CreateSubscriptionTradeRequest request, Long customerId);
 
+    void processSubscriptionRequest(Long estateId, Long customerId, int requestedAmount, int tokenPrice);
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
@@ -311,8 +311,9 @@ public class TradeServiceImpl implements TradeService {
     }
 
     // 청약 신청 처리 로직
+    @Override
     @Transactional
-    public void processSubscription(Long estateId, Long customerId, int requestedAmount, int tokenPrice) {
+    public void processSubscriptionRequest(Long estateId, Long customerId, int requestedAmount, int tokenPrice) {
         // 1. 매물 상태 확인 (RUNNING 상태만 허용)
         Estate estate = estateRepository.findById(estateId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ESTATE_NOT_FOUND));
@@ -320,6 +321,7 @@ public class TradeServiceImpl implements TradeService {
         if (estate.getEstateStatus() != EstateStatus.RUNNING) {
             throw new CustomException(ErrorCode.ESTATE_NOT_RUNNING);
         }
+
         // 2. 사용자 존재 확인
         Customer customer = customerRepository.findById(customerId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -341,7 +343,7 @@ public class TradeServiceImpl implements TradeService {
                 .subStatus(SubStatus.PENDING)
                 .build();
         subscriptionRepository.save(subscription);
-        log.info("청약 성공 - estateId: {}, customerId: {}", estateId, customerId);
+        log.info("청약 요청 DB에 저장 성공 - estateId: {}, customerId: {}", estateId, customerId);
     }
 
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
@@ -6,6 +6,7 @@ import com.piehouse.woorepie.customer.repository.AccountRepository;
 import com.piehouse.woorepie.customer.repository.CustomerRepository;
 import com.piehouse.woorepie.estate.dto.RedisEstatePrice;
 import com.piehouse.woorepie.estate.entity.Estate;
+import com.piehouse.woorepie.estate.entity.EstateStatus;
 import com.piehouse.woorepie.estate.repository.EstateRepository;
 import com.piehouse.woorepie.global.exception.CustomException;
 import com.piehouse.woorepie.global.exception.ErrorCode;
@@ -13,6 +14,7 @@ import com.piehouse.woorepie.global.kafka.dto.SubscriptionRequestEvent;
 import com.piehouse.woorepie.global.kafka.dto.TransactionCreatedEvent;
 import com.piehouse.woorepie.global.kafka.dto.OrderCreatedEvent;
 import com.piehouse.woorepie.global.kafka.service.KafkaProducerService;
+import com.piehouse.woorepie.subscription.entity.Subscription;
 import com.piehouse.woorepie.trade.dto.request.*;
 import com.piehouse.woorepie.notification.service.NotificationService;
 import com.piehouse.woorepie.trade.dto.request.BuyEstateRequest;
@@ -25,9 +27,13 @@ import com.piehouse.woorepie.trade.repository.TradeRepository;
 import com.piehouse.woorepie.trade.service.TradeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
 import com.piehouse.woorepie.subscription.repository.SubscriptionRepository;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -312,7 +318,7 @@ public class TradeServiceImpl implements TradeService {
         Estate estate = estateRepository.findById(estateId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ESTATE_NOT_FOUND));
 
-        if (estate.getSubState() != SubState.RUNNING) {
+        if (estate.getEstateStatus() != EstateStatus.RUNNING) {
             throw new CustomException(ErrorCode.ESTATE_NOT_RUNNING);
         }
 

--- a/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
@@ -14,6 +14,7 @@ import com.piehouse.woorepie.global.kafka.dto.SubscriptionRequestEvent;
 import com.piehouse.woorepie.global.kafka.dto.TransactionCreatedEvent;
 import com.piehouse.woorepie.global.kafka.dto.OrderCreatedEvent;
 import com.piehouse.woorepie.global.kafka.service.KafkaProducerService;
+import com.piehouse.woorepie.subscription.entity.SubStatus;
 import com.piehouse.woorepie.subscription.entity.Subscription;
 import com.piehouse.woorepie.trade.dto.request.*;
 import com.piehouse.woorepie.notification.service.NotificationService;
@@ -310,10 +311,8 @@ public class TradeServiceImpl implements TradeService {
     }
 
     // 청약 신청 처리 로직
-    @Retryable(value = ObjectOptimisticLockingFailureException.class, maxAttempts = 3)
+    @Transactional
     public void processSubscription(Long estateId, Long customerId, int requestedAmount, int tokenPrice) {
-        String redisKey = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
-
         // 1. 매물 상태 확인 (RUNNING 상태만 허용)
         Estate estate = estateRepository.findById(estateId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ESTATE_NOT_FOUND));
@@ -321,58 +320,28 @@ public class TradeServiceImpl implements TradeService {
         if (estate.getEstateStatus() != EstateStatus.RUNNING) {
             throw new CustomException(ErrorCode.ESTATE_NOT_RUNNING);
         }
+        // 2. 사용자 존재 확인
+        Customer customer = customerRepository.findById(customerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        // 2. Redis 토큰 선점
-        Long newRemaining = redisTemplate.opsForValue().decrement(redisKey, requestedAmount);
-        if (newRemaining == null || newRemaining < 0) {
-            redisTemplate.opsForValue().increment(redisKey, requestedAmount); // 롤백
-            throw new CustomException(ErrorCode.TOKEN_INSUFFICIENT);
+        // 3. 고객 계좌 차감
+        int totalPrice = requestedAmount * tokenPrice;
+        int updatedRows = customerRepository.decreaseBalance(customerId, totalPrice);
+
+        if (updatedRows == 0) {
+            throw new CustomException(ErrorCode.INSUFFICIENT_CASH);
         }
 
-        try {
-            executeInTransaction(() -> {
-                Customer customer = customerRepository.findById(customerId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-                // 3. 고객 계좌 차감
-                int totalPrice = requestedAmount * tokenPrice;
-                int updatedRows = customerRepository.decreaseBalance(customerId, totalPrice);
-
-                if (updatedRows == 0) {
-                    throw new CustomException(ErrorCode.INSUFFICIENT_CASH);
-                }
-
-                // 4. 청약 기록 저장
-                Subscription subscription = Subscription.builder()
-                        .estate(estate)
-                        .customer(customer)
-                        .subTokenAmount(requestedAmount)
-                        .subDate(LocalDateTime.now()) // 현재 시각 저장
-                        .build();
-                subscriptionRepository.save(subscription);
-                log.info("청약 성공 - estateId: {}, customerId: {}", estateId, customerId);
-            });
-        } catch (DataIntegrityViolationException e) {
-            // Unique 제약조건 위반 (중복 청약)
-            redisTemplate.opsForValue().increment(redisKey, requestedAmount); // Redis 롤백
-            log.error("중복 청약 시도 - estateId: {}, customerId: {}", estateId, customerId);
-            throw new CustomException(ErrorCode.DUPLICATE_SUBSCRIPTION);
-        } catch (Exception e) {
-            redisTemplate.opsForValue().increment(redisKey, requestedAmount); // Redis 롤백
-            log.error("청약 처리 실패 - estateId: {}, customerId: {}", estateId, customerId, e);
-            throw e;
-        }
-    }
-
-    private void executeInTransaction(Runnable action) {
-
-        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
-        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
-        transactionTemplate.execute(status -> {
-            action.run();
-            return null;
-        });
-
+        // 4. 청약 기록 저장
+        Subscription subscription = Subscription.builder()
+                .estate(estate)
+                .customer(customer)
+                .subTokenAmount(requestedAmount)
+                .subDate(LocalDateTime.now()) // 현재 시각 저장
+                .subStatus(SubStatus.PENDING)
+                .build();
+        subscriptionRepository.save(subscription);
+        log.info("청약 성공 - estateId: {}, customerId: {}", estateId, customerId);
     }
 
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
@@ -258,7 +258,7 @@ public class TradeServiceImpl implements TradeService {
     @Override
     @Transactional
     public void createSubscription(CreateSubscriptionTradeRequest request, Long customerId) {
-
+        log.info("청약 신청 serviceimpl createSubscription 들어옴");
         Customer customer = customerRepository.findById(customerId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
@@ -304,6 +304,7 @@ public class TradeServiceImpl implements TradeService {
                 SubscriptionRequestEvent.builder()
                         .customerId(customerId)
                         .estateId(estateId)
+                        .tokenPrice(subscriptionCost)
                         .amount(requestAmount)
                         .subscribeDate(now)
                         .build()

--- a/woorepie/src/main/resources/application.properties
+++ b/woorepie/src/main/resources/application.properties
@@ -30,7 +30,7 @@ spring.kafka.bootstrap-servers=${KAFKA_IP}
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
 spring.kafka.producer.properties.spring.json.trusted.packages=com.piehouse.woorepie.global.kafka.dto
-spring.kafka.producer.properties.spring.json.add.type.headers=false
+spring.kafka.producer.properties.spring.json.add.type.headers=true
 # Consumer
 spring.kafka.consumer.group-id=${KAFKA_CONSUMER_GROUP}
 spring.kafka.consumer.auto-offset-reset=earliest


### PR DESCRIPTION
## ✨ 작업 개요
- 청약(Subscription) 신청 시 기존 실시간 처리 대신 모든 요청을 DB에 pending 상태로 저장하고, 모집 완료/실패 시점에 admin Kafka 이벤트를 통해 일괄적으로 결과(성공/실패)를 처리하는 구조로 변경하였습니다.
- Estate(매물) 엔티티의 상태 필드를 SubState에서 EstateStatus로 변경하였고, Subscription 엔티티에 청약 상태(SubStatus) 필드를 추가하였습니다.

## ✅ 작업 목록
- [x] 청약 신청 시 pending 상태로 DB에 저장하는 로직 구현
- [x] Subscription(청약 내역) 테이블에 SubStatus(상태) 필드 추가 (pending, success, failure 등)
- [x] Estate 엔티티의 상태 필드명 SubState → EstateStatus로 변경
- [x] Kafka subscription.request 발행 및 계좌 잔액 차감 로직 수정
- [x] admin의 Kafka 이벤트(subscription.success, subscription.failure) 수신 처리 및 일괄 상태 업데이트
- [x] 청약 성공/실패 내역 분리 및 결과 저장
- [x] 성공 시 subscription.accept 이벤트 발행, 실패 시 환불 처리 로직 추가
- [x] Redis 조회 시 타입 안전성 확보(ObjectMapper 변환 패턴 적용)

## 📎 관련 이슈
- #70 

## 📌 추가 설명
- 기존에는 카프카 비동기 구조로 인해 프론트엔드에서 사용자가 실시간으로 청약 결과를 확인하기 어려웠으나, 일괄 처리 구조로 개선하여 사용자 경험 및 후속 처리(토큰 지급/환불)의 명확성을 확보하였습니다.