### PR TITLE
[FIX]s3 정적파일 등록시 client가 파일 읽기 권한 허가해주는 로직 추가

### DIFF
--- a/woorepie/src/main/java/com/piehouse/woorepie/global/service/implement/S3ServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/service/implement/S3ServiceImpl.java
@@ -57,6 +57,7 @@ public class S3ServiceImpl implements S3Service {
                 .bucket(bucketName)
                 .key(objectKey)
                 .contentType(s3request.getFileType())
+                .acl("public-read") // ✅ 퍼블릭 읽기 권한 추가
                 .build();
 
         PresignedPutObjectRequest presignedRequest = presigner.presignPutObject(p -> p
@@ -95,6 +96,7 @@ public class S3ServiceImpl implements S3Service {
                             .bucket(bucketName)
                             .key(objectKey)
                             .contentType(contentType)
+                            .acl("public-read") // ✅ 퍼블릭 읽기 권한 추가
                             .build();
 
                     PresignedPutObjectRequest presignedRequest = presigner.presignPutObject(p -> p
@@ -138,6 +140,7 @@ public class S3ServiceImpl implements S3Service {
                             .bucket(bucketName)
                             .key(objectKey)
                             .contentType(contentType)
+                            .acl("public-read") // ✅ 퍼블릭 읽기 권한 추가
                             .build();
 
                     PresignedPutObjectRequest presignedRequest = presigner.presignPutObject(p -> p


### PR DESCRIPTION
## ✨ 작업 개요
agent 가 매물 등록시에 매물과 관련된  파일들을 등록할 때 client 가 읽을 수 있게 권한을 주는 로직을  추가

## ✅ 작업 목록
- [x] s3 serviceImpl 파일 수정
