### PR TITLE
[FIX] agent 마이페이지 매물 리스트 토큰당 가격, 배당률 표시 오류 수정

### DIFF
--- a/woorepie/src/main/java/com/piehouse/woorepie/agent/service/implement/AgentServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/agent/service/implement/AgentServiceImpl.java
@@ -8,11 +8,13 @@ import com.piehouse.woorepie.agent.dto.response.GetAgentResponse;
 import com.piehouse.woorepie.agent.entity.Agent;
 import com.piehouse.woorepie.agent.repository.AgentRepository;
 import com.piehouse.woorepie.agent.service.AgentService;
+import com.piehouse.woorepie.estate.dto.RedisEstatePrice;
+import com.piehouse.woorepie.estate.entity.Dividend;
 import com.piehouse.woorepie.estate.entity.Estate;
-import com.piehouse.woorepie.estate.entity.EstatePrice;
 import com.piehouse.woorepie.estate.repository.DividendRepository;
 import com.piehouse.woorepie.estate.repository.EstatePriceRepository;
 import com.piehouse.woorepie.estate.repository.EstateRepository;
+import com.piehouse.woorepie.estate.service.EstateRedisService;
 import com.piehouse.woorepie.global.exception.CustomException;
 import com.piehouse.woorepie.global.exception.ErrorCode;
 import com.piehouse.woorepie.global.service.implement.S3ServiceImpl;
@@ -31,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -43,6 +46,7 @@ public class AgentServiceImpl implements AgentService {
     private final DividendRepository dividendRepository;
     private final PasswordEncoder passwordEncoder;
     private final S3ServiceImpl s3Service;
+    private final EstateRedisService estateRedisService;
 
     @Override
     @Transactional(readOnly = true)
@@ -152,22 +156,26 @@ public class AgentServiceImpl implements AgentService {
     @Override
     @Transactional(readOnly = true)
     public List<AgentEstateListResponse> getEstatesByAgent(Long agentId) {
-        // 수정 전
-        // List<Estate> estateList = estateRepository.findByAgentId(agentId);
-
-        // ✅ 수정 후
+        // 1. DB에서 agent의 estate 목록 조회
         List<Estate> estateList = estateRepository.findByAgent_AgentId(agentId);
 
+        // 2. estateId만 리스트로 추출
+        List<Long> estateIds = estateList.stream()
+                .map(Estate::getEstateId)
+                .toList();
+
+        // 3. Redis에서 estateId 리스트로 가격 정보 한꺼번에 조회
+        Map<Long, RedisEstatePrice> estatePriceMap = estateRedisService.getMultipleRedisEstatePrice(estateIds);
+
+        // 4. estateList를 돌면서 각 estate에 price를 할당해서 응답 생성
         return estateList.stream()
                 .map(e -> {
-                    Integer estateTokenPrice = estatePriceRepository
-                            .findTopByEstate_EstateIdOrderByEstatePriceDateDesc(e.getEstateId())
-                            .map(EstatePrice::getEstatePrice)
-                            .orElse(null);
+                    RedisEstatePrice price = estatePriceMap.get(e.getEstateId());
+                    int estateTokenPrice = price != null ? price.getEstateTokenPrice() : 0; // int로 바로 할당
 
                     BigDecimal dividendYield = dividendRepository
                             .findTopByEstate_EstateIdOrderByDividendDateDesc(e.getEstateId())
-                            .map(d -> d.getDividendYield())
+                            .map(Dividend::getDividendYield)
                             .orElse(null);
 
                     return AgentEstateListResponse.builder()
@@ -181,5 +189,4 @@ public class AgentServiceImpl implements AgentService {
                 })
                 .toList();
     }
-
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/agent/service/implement/AgentServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/agent/service/implement/AgentServiceImpl.java
@@ -172,18 +172,15 @@ public class AgentServiceImpl implements AgentService {
                 .map(e -> {
                     RedisEstatePrice price = estatePriceMap.get(e.getEstateId());
                     int estateTokenPrice = price != null ? price.getEstateTokenPrice() : 0; // int로 바로 할당
+                    BigDecimal dividend = price != null ? price.getDividendYield() : BigDecimal.ZERO; // int로 바로 할당
 
-                    BigDecimal dividendYield = dividendRepository
-                            .findTopByEstate_EstateIdOrderByDividendDateDesc(e.getEstateId())
-                            .map(Dividend::getDividendYield)
-                            .orElse(null);
-
+                    assert price != null;
                     return AgentEstateListResponse.builder()
                             .estateId(e.getEstateId())
                             .estateName(e.getEstateName())
                             .tokenAmount(e.getTokenAmount())
                             .estateTokenPrice(estateTokenPrice)
-                            .dividendYield(dividendYield)
+                            .dividendYield(dividend)
                             .estateStatus(e.getEstateStatus().name())
                             .build();
                 })


### PR DESCRIPTION
## ✨ 작업 개요
Agent 마이페이지에서 매물 리스트 조회 시, 
각 매물의 토큰당 가격과 배당률이 실제 Redis에 저장된 가격과 다르게 표시되는 문제 수정

## ✅ 작업 목록
- [x] 매물 리스트에서 estateId 리스트 추출 후, Redis에서 일괄로 가격 정보를 조회하도록 수정
- [x] 배당률 Redis에서 조회하도록 변경

## 📎 관련 이슈
- resolve #88