### PR TITLE
[FEAT] 거래 체결 시 Customer 잔액 반영 기능 추가

### DIFF
--- a/woorepie/src/main/java/com/piehouse/woorepie/customer/entity/Customer.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/customer/entity/Customer.java
@@ -59,14 +59,6 @@ public class Customer {
     @Column(length = 1000, nullable = false, unique = true)
     private String customerIdentificationUrl;
 
-    // 계좌 잔액 감소 메서드 추가
-    public void decreaseBalance(int amount) {
-        if (this.accountBalance < amount) {
-            throw new CustomException(ErrorCode.INSUFFICIENT_CASH);
-        }
-        this.accountBalance -= amount;
-    }
-
     // 계좌 잔액 에 배당금 추가
     public void setAccountBalance(int accountBalance) {
         this.accountBalance = accountBalance;
@@ -79,6 +71,19 @@ public class Customer {
 
     public void plusAccountBalance(Integer price) {
         this.accountBalance += price;
+    }
+
+    // 계좌 잔액 증가
+    public void increaseAccountBalance(int amount) {
+        this.accountBalance += amount;
+    }
+
+    // 계좌 잔액 감소 메서드 추가
+    public void decreaseAccountBalance(int amount) {
+        if (this.accountBalance < amount) {
+            throw new CustomException(ErrorCode.INSUFFICIENT_CASH);
+        }
+        this.accountBalance -= amount;
     }
 
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/customer/entity/Customer.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/customer/entity/Customer.java
@@ -69,10 +69,6 @@ public class Customer {
         this.customerPassword = newPassword;
     }
 
-    public void plusAccountBalance(Integer price) {
-        this.accountBalance += price;
-    }
-
     // 계좌 잔액 증가
     public void increaseAccountBalance(int amount) {
         this.accountBalance += amount;

--- a/woorepie/src/main/java/com/piehouse/woorepie/customer/service/implement/CustomerServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/customer/service/implement/CustomerServiceImpl.java
@@ -243,7 +243,7 @@ public class CustomerServiceImpl implements CustomerService {
         Customer customer = customerRepository.findById(customerId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        customer.plusAccountBalance(price);
+        customer.increaseAccountBalance(price);
         customerRepository.save(customer);
         
     }

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/entity/Estate.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/entity/Estate.java
@@ -101,13 +101,4 @@ public class Estate {
         this.estateDescription = newDescription;
         return this;
     }
-
-    public void updateEstateStatusToSuccess() {
-        this.estateStatus = EstateStatus.SUCCESS;
-    }
-
-    public void updateEstateStatusToExit() {
-        this.estateStatus = EstateStatus.EXIT;
-    }
-
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/impliment/KafkaConsumerServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/global/kafka/service/impliment/KafkaConsumerServiceImpl.java
@@ -140,7 +140,6 @@ public class KafkaConsumerServiceImpl implements KafkaConsumerService {
                 .orElseThrow(() -> new CustomException(ErrorCode.ESTATE_NOT_FOUND));
 
         // 2. 상태 EXIT 변경
-        estate.updateEstateStatusToExit();
         estateRepository.save(estate);
 
         // 3. 최근 시세 조회

--- a/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
@@ -99,6 +99,9 @@ public class TradeServiceImpl implements TradeService {
         sellerAccount.updateTokenAmount(newTokenAmount)
                 .updateTotalAmount(newTotalAmount);
 
+        // 판매자 계좌 잔액 증가
+        seller.increaseAccountBalance(tradeAmount);
+
         // 5. 구매자 계좌 업데이트
         Account buyerAccount = accountRepository.findByCustomerAndEstate(buyer, estate)
                 .orElseGet(() -> {
@@ -115,6 +118,9 @@ public class TradeServiceImpl implements TradeService {
         // 구매자 계좌 업데이트 - 토큰과 금액 모두 증가
         buyerAccount.updateTokenAmount(buyerAccount.getAccountTokenAmount() + tradeTokenAmount)
                 .updateTotalAmount(buyerAccount.getTotalAccountAmount() + tradeAmount);
+
+        // 구매자 계좌 잔액 차감
+        buyer.decreaseAccountBalance(tradeAmount);
 
         return savedTrade;
 

--- a/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
@@ -60,6 +60,11 @@ public class TradeServiceImpl implements TradeService {
     @Override
     @Transactional
     public Trade saveTrade(Estate estate, Customer seller, Customer buyer, int tradeTokenAmount, int tokenPrice) {
+        Customer persistedSeller = customerRepository.findById(seller.getCustomerId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Customer persistedBuyer = customerRepository.findById(buyer.getCustomerId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // PostgreSQL 저장
         LocalDateTime tradeTime = LocalDateTime.now();
@@ -100,7 +105,7 @@ public class TradeServiceImpl implements TradeService {
                 .updateTotalAmount(newTotalAmount);
 
         // 판매자 계좌 잔액 증가
-        seller.increaseAccountBalance(tradeAmount);
+        persistedSeller.increaseAccountBalance(tradeAmount);
 
         // 5. 구매자 계좌 업데이트
         Account buyerAccount = accountRepository.findByCustomerAndEstate(buyer, estate)
@@ -120,7 +125,7 @@ public class TradeServiceImpl implements TradeService {
                 .updateTotalAmount(buyerAccount.getTotalAccountAmount() + tradeAmount);
 
         // 구매자 계좌 잔액 차감
-        buyer.decreaseAccountBalance(tradeAmount);
+        persistedBuyer.decreaseAccountBalance(tradeAmount);
 
         return savedTrade;
 


### PR DESCRIPTION
## ✨ 작업 개요
거래 체결 시 Customer 테이블의 accountBalance 필드에도 잔액이 반영되도록 기능을 추가하였습니다.  
또한 JPA 영속성 문제로 인해 필드 변경이 저장되지 않는 이슈를 해결하기 위해 seller, buyer를 영속 상태로 재조회하도록 수정하였습니다.

## ✅ 작업 목록
- [x] 매수자 accountBalance 차감 로직 추가 (`decreaseAccountBalance`)
- [x] 매도자 accountBalance 증가 로직 추가 (`increaseAccountBalance`)
- [x] saveTrade 내 seller, buyer를 영속 상태로 재조회하도록 수정
- [x] 관련 메서드 네이밍 통일 및 타입 일관성 확보

## 📎 관련 이슈
- resolve #93