### PR TITLE
[TEST] 청약 서비스 로직 단위 테스트 및 시나리오별 Mock 테스트 추가

### DIFF
--- a/woorepie/src/test/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImplTest.java
+++ b/woorepie/src/test/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImplTest.java
@@ -128,6 +128,25 @@ class SubscriptionServiceImplTest {
     }
 
     /**
+     * [경계 케이스] 청약 매물 리스트 - 데이터 없음(empty)
+     * - DB에 청약 가능한 매물이 0건일 때 정상적으로 빈 리스트가 반환되는지 검증
+     */
+    @Test
+    @DisplayName("청약 매물 리스트 - 데이터 없음(empty)")
+    void getActiveSubscriptions_empty() {
+        // given: 조회 결과가 아예 없는 상황
+        given(estateRepository.findByEstateStatusIn(anyList())).willReturn(List.of());
+        given(estateRedisServiceImpl.getMultipleRedisEstatePrice(anyList())).willReturn(Map.of());
+
+        // when
+        List<GetSubscriptionSimpleResponse> result = subscriptionService.getActiveSubscriptions();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+    /**
      * [정상 케이스] 청약 매물 상세정보 조회
      */
     @Test

--- a/woorepie/src/test/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImplTest.java
+++ b/woorepie/src/test/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImplTest.java
@@ -1,0 +1,282 @@
+package com.piehouse.woorepie.subscription.service.implement;
+
+import com.piehouse.woorepie.agent.entity.Agent;
+import com.piehouse.woorepie.agent.repository.AgentRepository;
+import com.piehouse.woorepie.customer.entity.Account;
+import com.piehouse.woorepie.customer.entity.Customer;
+import com.piehouse.woorepie.customer.repository.AccountRepository;
+import com.piehouse.woorepie.customer.repository.CustomerRepository;
+import com.piehouse.woorepie.estate.dto.RedisEstatePrice;
+import com.piehouse.woorepie.estate.entity.Estate;
+import com.piehouse.woorepie.estate.entity.EstateStatus;
+import com.piehouse.woorepie.estate.repository.EstateRepository;
+import com.piehouse.woorepie.estate.service.implement.EstateRedisServiceImpl;
+import com.piehouse.woorepie.global.exception.CustomException;
+import com.piehouse.woorepie.global.exception.ErrorCode;
+import com.piehouse.woorepie.global.kafka.service.KafkaProducerService;
+import com.piehouse.woorepie.global.service.implement.S3ServiceImpl;
+import com.piehouse.woorepie.notification.service.NotificationService;
+import com.piehouse.woorepie.subscription.dto.request.RegisterEstateRequest;
+import com.piehouse.woorepie.subscription.dto.response.GetSubscriptionDetailsResponse;
+import com.piehouse.woorepie.subscription.dto.response.GetSubscriptionSimpleResponse;
+import com.piehouse.woorepie.subscription.entity.SubStatus;
+import com.piehouse.woorepie.subscription.entity.Subscription;
+import com.piehouse.woorepie.subscription.repository.SubscriptionRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.ArgumentMatchers.*;
+
+/**
+ * SubscriptionServiceImpl 단위테스트
+ * - 주요 비즈니스 로직별 Mock 기반 단위 테스트 작성
+ * - 모든 주요 서비스 로직(등록/조회/상태변경/환불) 정상·비정상 플로우 커버
+ * - 산출물 제출 및 자동화 테스트에 활용 가능한 통합 단위테스트 템플릿
+ */
+class SubscriptionServiceImplTest {
+
+    @Mock private EstateRepository estateRepository;
+    @Mock private AgentRepository agentRepository;
+    @Mock private EstateRedisServiceImpl estateRedisServiceImpl;
+    @Mock private S3ServiceImpl s3serviceImpl;
+    @Mock private SubscriptionRepository subscriptionRepository;
+    @Mock private KafkaProducerService kafkaProducerService;
+    @Mock private CustomerRepository customerRepository;
+    @Mock private AccountRepository accountRepository;
+    @Mock private NotificationService notificationService;
+
+    @InjectMocks
+    private SubscriptionServiceImpl subscriptionService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    /**
+     * [정상 케이스] 매물 등록 기능 단위테스트
+     * - Agent가 정상적으로 존재하고 모든 의존 mock이 정상 동작할 때 예외 없이 저장되는지 검증
+     */
+    @Test
+    @DisplayName("매물 등록 성공")
+    void registerEstate_success() {
+        Long agentId = 1L;
+        RegisterEstateRequest request = mock(RegisterEstateRequest.class);
+        Agent agent = mock(Agent.class);
+
+        given(agent.getAgentEmail()).willReturn("woori@woorepie.com");
+        given(agentRepository.findById(agentId)).willReturn(Optional.of(agent));
+        given(s3serviceImpl.getPublicS3Url(any())).willReturn("http://img.com/file.png");
+
+        assertThatNoException().isThrownBy(() -> subscriptionService.registerEstate(request, agentId));
+        then(estateRepository).should(times(1)).save(any(Estate.class));
+    }
+
+    /**
+     * [비정상 케이스] 매물 등록 실패 - Agent 미존재 시 예외 처리 검증
+     */
+    @Test
+    @DisplayName("매물 등록 실패 - Agent 미존재")
+    void registerEstate_fail_noAgent() {
+        Long agentId = 99L;
+        RegisterEstateRequest request = mock(RegisterEstateRequest.class);
+        given(agentRepository.findById(agentId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> subscriptionService.registerEstate(request, agentId))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    /**
+     * [정상 케이스] 청약 매물 리스트 조회
+     * - DB/Redis에서 정상적으로 매물 정보 및 시세정보가 조회되고, 변환 로직이 정상 동작하는지 검증
+     */
+    @Test
+    @DisplayName("청약 매물 리스트 정상 조회")
+    void getActiveSubscriptions_success() {
+        Estate estate = mock(Estate.class);
+        Agent agent = mock(Agent.class);
+
+        given(estate.getEstateId()).willReturn(1L);
+        given(estate.getAgent()).willReturn(agent);
+        given(estateRepository.findByEstateStatusIn(anyList())).willReturn(List.of(estate));
+        RedisEstatePrice price = mock(RedisEstatePrice.class);
+        given(price.getTokenAmount()).willReturn(10);
+        given(price.getEstatePrice()).willReturn(1000000);
+        given(price.getEstateTokenPrice()).willReturn(1000);
+        given(price.getDividendYield()).willReturn(BigDecimal.valueOf(5.5));
+        Map<Long, RedisEstatePrice> priceMap = Map.of(1L, price);
+        given(estateRedisServiceImpl.getMultipleRedisEstatePrice(anyList())).willReturn(priceMap);
+
+        List<GetSubscriptionSimpleResponse> result = subscriptionService.getActiveSubscriptions();
+
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(1);
+        then(estateRepository).should(times(1)).findByEstateStatusIn(anyList());
+        then(estateRedisServiceImpl).should(times(1)).getMultipleRedisEstatePrice(anyList());
+    }
+
+    /**
+     * [정상 케이스] 청약 매물 상세정보 조회
+     */
+    @Test
+    @DisplayName("청약 매물 상세 조회 성공")
+    void getSubscriptionDetails_success() {
+        Long estateId = 10L;
+        Estate estate = mock(Estate.class);
+        Agent agent = mock(Agent.class);
+
+        given(estateRepository.findById(estateId)).willReturn(Optional.of(estate));
+        given(estateRedisServiceImpl.getRedisEstatePrice(estateId)).willReturn(mock(RedisEstatePrice.class));
+        given(estate.getAgent()).willReturn(agent);
+        given(agent.getBusinessName()).willReturn("우리공인");
+        given(estate.getTokenAmount()).willReturn(10);
+
+        GetSubscriptionDetailsResponse response = subscriptionService.getSubscriptionDetails(estateId);
+
+        assertThat(response).isNotNull();
+        then(estateRepository).should(times(1)).findById(estateId);
+    }
+
+    /**
+     * [비정상 케이스] 청약 매물 상세 조회 실패 - estate 미존재
+     */
+    @Test
+    @DisplayName("청약 매물 상세 조회 실패 - estate 미존재")
+    void getSubscriptionDetails_fail_noEstate() {
+        Long estateId = 1234L;
+        given(estateRepository.findById(estateId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> subscriptionService.getSubscriptionDetails(estateId))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.ESTATE_NOT_FOUND.getMessage());
+    }
+
+    /**
+     * [복합 플로우] 청약 성공(선착순 배정) 로직
+     * - 전체 성공, 부분 성공, 실패 등 케이스를 Mock으로 분기 세팅 후, 로직 정상 동작 검증
+     * - 성공/실패/부분 성공/계좌생성, 알림, kafka 연동 등
+     */
+    @Test
+    @DisplayName("청약 성공 로직 - 전체 성공/부분 성공/실패")
+    void updateSubscriptionsOnSuccess_logic() {
+        Long estateId = 1L;
+        Estate estate = mock(Estate.class);
+
+        given(estateRepository.findById(estateId)).willReturn(Optional.of(estate));
+        given(estate.getTokenAmount()).willReturn(5);
+
+        RedisEstatePrice redisPrice = mock(RedisEstatePrice.class);
+        given(redisPrice.getEstateTokenPrice()).willReturn(1000);
+        given(estateRedisServiceImpl.getRedisEstatePrice(estateId)).willReturn(redisPrice);
+
+        // 두 명의 고객이 각각 3개, 4개씩 신청 (총 5개만 가능)
+        Customer customer1 = mock(Customer.class);
+        Customer customer2 = mock(Customer.class);
+        given(customer1.getCustomerId()).willReturn(11L);
+        given(customer2.getCustomerId()).willReturn(12L);
+
+        Subscription sub1 = mock(Subscription.class);
+        Subscription sub2 = mock(Subscription.class);
+
+        given(sub1.getSubTokenAmount()).willReturn(3);
+        given(sub2.getSubTokenAmount()).willReturn(4);
+        given(sub1.getCustomer()).willReturn(customer1);
+        given(sub2.getCustomer()).willReturn(customer2);
+        given(sub1.getEstate()).willReturn(estate);
+        given(sub2.getEstate()).willReturn(estate);
+        given(sub1.getSubDate()).willReturn(LocalDateTime.now());
+        given(sub2.getSubDate()).willReturn(LocalDateTime.now());
+        given(sub1.getSubStatus()).willReturn(SubStatus.PENDING);
+        given(sub2.getSubStatus()).willReturn(SubStatus.PENDING);
+
+        // accountRepository, Account mock (Optional 타입 주의!)
+        Account account1 = mock(Account.class);
+        given(accountRepository.findByCustomerAndEstate(eq(customer1), eq(estate))).willReturn(Optional.of(account1));
+        given(accountRepository.findByCustomerAndEstate(eq(customer2), eq(estate))).willReturn(Optional.empty());
+
+        // customerRepository (환불 때)
+        given(customerRepository.increaseBalance(anyLong(), anyInt())).willReturn(1);
+
+        // 알림 mock
+        willDoNothing().given(notificationService).sendSubscriptionSuccessNotification(any(), any(), anyInt(), anyInt(), any());
+        willDoNothing().given(notificationService).sendSubscriptionFailSoldoutNotification(any(), any(), anyInt(), anyInt(), any());
+
+        // 선착순 배정 Pending list
+        given(subscriptionRepository.findAllByEstate_EstateIdAndSubStatusOrderBySubDateAsc(estateId, SubStatus.PENDING))
+                .willReturn(List.of(sub1, sub2));
+
+        assertThatNoException().isThrownBy(() -> subscriptionService.updateSubscriptionsOnSuccess(estateId));
+        then(estateRepository).should(atLeastOnce()).save(any(Estate.class));
+    }
+
+    /**
+     * [복합 플로우] 청약 실패 처리
+     * - 전체 Pending → 실패 처리 및 환불, 알림, 상태변경 등 검증
+     */
+    @Test
+    @DisplayName("청약 실패 처리 - 전체 pending 실패")
+    void updateSubscriptionsOnFailure_success() {
+        Long estateId = 1L;
+        Estate estate = mock(Estate.class);
+
+        Customer customer = mock(Customer.class);
+        given(customer.getCustomerId()).willReturn(100L);
+
+        Subscription sub1 = mock(Subscription.class);
+        given(sub1.getCustomer()).willReturn(customer);
+        given(sub1.getEstate()).willReturn(estate);
+        given(sub1.getSubTokenAmount()).willReturn(2);
+        given(sub1.getSubDate()).willReturn(LocalDateTime.now());
+        Subscription sub2 = mock(Subscription.class);
+        given(sub2.getCustomer()).willReturn(customer);
+        given(sub2.getEstate()).willReturn(estate);
+        given(sub2.getSubTokenAmount()).willReturn(3);
+        given(sub2.getSubDate()).willReturn(LocalDateTime.now());
+
+        List<Subscription> pendingList = List.of(sub1, sub2);
+
+        given(subscriptionRepository.findAllByEstate_EstateIdAndSubStatus(estateId, SubStatus.PENDING))
+                .willReturn(pendingList);
+        RedisEstatePrice price = mock(RedisEstatePrice.class);
+        given(price.getEstateTokenPrice()).willReturn(500);
+        given(estateRedisServiceImpl.getRedisEstatePrice(estateId)).willReturn(price);
+        given(estateRepository.findById(estateId)).willReturn(Optional.of(estate));
+        given(customerRepository.increaseBalance(anyLong(), anyInt())).willReturn(1);
+        willDoNothing().given(notificationService).sendSubscriptionFailLackNotification(any(), any(), anyInt(), anyInt(), any());
+
+        assertThatNoException().isThrownBy(() -> subscriptionService.updateSubscriptionsOnFailure(estateId));
+        then(subscriptionRepository).should().saveAll(pendingList);
+        then(estateRepository).should().save(estate);
+    }
+
+    /**
+     * [비정상 케이스] 청약 실패 환불 - 예외 발생
+     * - 환불 대상 고객의 계좌가 존재하지 않아 예외처리 발생
+     */
+    @Test
+    @DisplayName("청약 실패 환불 - 예외 발생")
+    void refundSubscriptionFailure_fail() {
+        Subscription sub = mock(Subscription.class);
+        Customer customer = mock(Customer.class);
+        given(sub.getCustomer()).willReturn(customer);
+        given(customer.getCustomerId()).willReturn(123L);
+        given(sub.getSubTokenAmount()).willReturn(2);
+        given(customerRepository.increaseBalance(eq(123L), anyInt())).willReturn(0);
+
+        assertThatThrownBy(() -> subscriptionService.refundSubscriptionFailure(sub, 1000))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.ACCOUNT_NON_EXIST.getMessage());
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요
- SubscriptionServiceImpl 단위 테스트 코드 추가
- 주요 서비스 로직(등록, 조회, 청약 성공/실패, 환불 등) 정상/예외 플로우 검증

## ✅ 작업 목록
- [x] 매물 등록 성공 테스트
- [x] 매물 등록 실패(Agent 미존재) 테스트
- [x] 청약 매물 리스트 정상 조회 테스트
- [x] 청약 매물 리스트 empty(데이터 없음) 테스트
- [x] 청약 매물 상세 조회 성공 테스트
- [x] 청약 매물 상세 조회 실패(미존재) 테스트
- [x] 청약 성공 플로우(전체/부분/실패) 테스트
- [x] 청약 실패 처리(전체 실패) 테스트
- [x] 청약 실패 환불(계좌 미존재 예외) 테스트

## 📎 관련 이슈
- resolve #99 