### PR TITLE
[TEST] Trade 서비스 로직 단위 테스트 및 시나리오별 Mock 테스트 추가

### DIFF
--- a/woorepie/src/test/java/com/piehouse/woorepie/trade/service/implement/TradeRedisServiceImplTest.java
+++ b/woorepie/src/test/java/com/piehouse/woorepie/trade/service/implement/TradeRedisServiceImplTest.java
@@ -1,93 +1,216 @@
 package com.piehouse.woorepie.trade.service.implement;
 
+import com.piehouse.woorepie.customer.entity.Customer;
+import com.piehouse.woorepie.customer.repository.CustomerRepository;
+import com.piehouse.woorepie.estate.entity.Estate;
+import com.piehouse.woorepie.estate.repository.EstateRepository;
+import com.piehouse.woorepie.global.exception.CustomException;
+import com.piehouse.woorepie.global.exception.ErrorCode;
+import com.piehouse.woorepie.global.kafka.dto.OrderCreatedEvent;
+import com.piehouse.woorepie.notification.service.NotificationService;
+import com.piehouse.woorepie.trade.dto.request.RedisCustomerTradeValue;
 import com.piehouse.woorepie.trade.dto.request.RedisEstateTradeValue;
 import com.piehouse.woorepie.trade.repository.RedisTradeRepository;
+import com.piehouse.woorepie.trade.service.TradeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.*;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
-import org.springframework.data.redis.core.RedisTemplate;
 
-import java.util.concurrent.*;
-import java.util.stream.IntStream;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-@ExtendWith(MockitoExtension.class)
+@DisplayName("TradeRedisServiceImpl 단위테스트")
 class TradeRedisServiceImplTest {
 
-    @Mock
-    private RedisTradeRepository redisRepository;
-    @Mock
-    private RedissonClient redissonClient;
-    @Mock
-    private RLock rLock;
-    @Mock
-    private RedisTemplate<String, Object> redisTemplate;
+    @Mock private RedisTradeRepository redisRepository;
+    @Mock private TradeService tradeService;
+    @Mock private EstateRepository estateRepository;
+    @Mock private CustomerRepository customerRepository;
+    @Mock private RedissonClient redissonClient;
+    @Mock private RLock rLock;
+    @Mock private NotificationService notificationService;
 
     @InjectMocks
     private TradeRedisServiceImpl tradeRedisService;
 
-    /**
-     * 분산 락 획득 및 해제 테스트
-     * - 락 획득 성공 시 매칭 로직 실행 여부 확인
-     * - finally 블록에서 락 해제가 정상적으로 이루어지는지 검증
-     */
-    @Test
-    void testLockAcquisitionAndRelease() throws InterruptedException {
-        // Given
-        when(redissonClient.getFairLock(anyString())).thenReturn(rLock);
-        when(rLock.tryLock(anyLong(), anyLong(), any())).thenReturn(true);
-        when(rLock.isHeldByCurrentThread()).thenReturn(true);
-
-        // When
-        tradeRedisService.processMatchingWithLock(1L);
-
-        // Then
-        verify(rLock).tryLock(anyLong(), anyLong(), any());
-        verify(rLock).unlock();
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
     }
 
     /**
-     * Lua 스크립트 원자성 검증 테스트
-     * - 100개의 병렬 주문 저장 시 스크립트가 원자적으로 실행되어 데이터 중복 없이 처리되는지 확인
+     * [정상 케이스] 매수 주문 저장 기능
+     * - Lua 스크립트를 이용한 원자적 저장 동작 여부 검증
      */
     @Test
-    void testLuaScriptAtomicity() {
-        // Given
-        lenient().when(redisTemplate.execute(any(), anyList(), any()))
-                .thenReturn(1L);
+    @DisplayName("매수 주문 저장 - Lua 스크립트 원자적 저장")
+    void saveBuyOrder_success() {
+        doNothing().when(redisRepository).saveOrUpdateBuyOrder(any(), anyLong(), any(), anyLong());
 
-        // When
-        IntStream.range(0, 100).parallel().forEach(i -> {
-            tradeRedisService.saveBuyOrder(1L, 100L + i, 10, 1000);
-        });
-
-        // Then
-        verify(redisRepository, times(100)).saveOrUpdateBuyOrder(any(), anyLong(), any(), anyLong());
+        assertThatNoException().isThrownBy(() ->
+                tradeRedisService.saveBuyOrder(1L, 2L, 10, 1000)
+        );
+        verify(redisRepository).saveOrUpdateBuyOrder(any(), eq(1L), any(), eq(2L));
     }
 
     /**
-     * 동시성 환경에서의 락 경쟁 테스트
-     * - 10개 스레드가 FairLock을 경쟁적으로 획득 시도할 때 순차적 처리(FIFO)가 이루어지는지 검증
-     * - 각 스레드가 락을 정상적으로 해제하는지 확인
+     * [정상 케이스] 매도 주문 저장 기능
+     * - Lua 스크립트를 이용한 원자적 저장 동작 여부 검증
      */
     @Test
-    void testConcurrentLockAccess() throws InterruptedException {
-        // Given
+    @DisplayName("매도 주문 저장 - Lua 스크립트 원자적 저장")
+    void saveSellOrder_success() {
+        doNothing().when(redisRepository).saveOrUpdateSellOrder(any(), anyLong(), any(), anyLong());
+
+        assertThatNoException().isThrownBy(() ->
+                tradeRedisService.saveSellOrder(1L, 2L, 10, 1000)
+        );
+        verify(redisRepository).saveOrUpdateSellOrder(any(), eq(1L), any(), eq(2L));
+    }
+
+    /**
+     * [정상 케이스] 매물 기준 매수/매도 주문 전체 조회
+     * - 조회 결과가 올바르게 반환되는지 검증
+     */
+    @Test
+    @DisplayName("매물 기준 매수/매도 주문 전체 조회")
+    void getEstateOrders_success() {
+        List<RedisEstateTradeValue> buyList = List.of(
+                new RedisEstateTradeValue(1L, 10, 1000, 111L)
+        );
+        List<RedisEstateTradeValue> sellList = List.of(
+                new RedisEstateTradeValue(2L, -5, 990, 112L)
+        );
+        when(redisRepository.getEstateBuyOrders(1L)).thenReturn(buyList);
+        when(redisRepository.getEstateSellOrders(1L)).thenReturn(sellList);
+
+        List<RedisEstateTradeValue> actualBuy = tradeRedisService.getEstateBuyOrders(1L);
+        List<RedisEstateTradeValue> actualSell = tradeRedisService.getEstateSellOrders(1L);
+
+        assertThat(actualBuy).isEqualTo(buyList);
+        assertThat(actualSell).isEqualTo(sellList);
+    }
+
+    /**
+     * [정상 케이스] 고객 기준 매수/매도 주문 전체 조회
+     * - 고객 ID별 주문 조회 정상 동작 검증
+     */
+    @Test
+    @DisplayName("고객 기준 매수/매도 주문 전체 조회")
+    void getCustomerOrders_success() {
+        List<RedisCustomerTradeValue> buyList = List.of(
+                new RedisCustomerTradeValue(1L, 10, 1000, 111L)
+        );
+        List<RedisCustomerTradeValue> sellList = List.of(
+                new RedisCustomerTradeValue(2L, -5, 990, 112L)
+        );
+        when(redisRepository.getCustomerBuyOrders(2L)).thenReturn(buyList);
+        when(redisRepository.getCustomerSellOrders(2L)).thenReturn(sellList);
+
+        List<RedisCustomerTradeValue> actualBuy = tradeRedisService.getCustomerBuyOrders(2L);
+        List<RedisCustomerTradeValue> actualSell = tradeRedisService.getCustomerSellOrders(2L);
+
+        assertThat(actualBuy).isEqualTo(buyList);
+        assertThat(actualSell).isEqualTo(sellList);
+    }
+
+    /**
+     * [정상 케이스] 가장 오래된 매수/매도 주문 pop 동작 검증
+     * - pop 결과가 정상 반환되는지 확인
+     */
+    @Test
+    @DisplayName("가장 오래된 매수/매도 주문 pop")
+    void popOldestOrders_success() {
+        RedisEstateTradeValue buy = new RedisEstateTradeValue(1L, 10, 1000, 111L);
+        RedisEstateTradeValue sell = new RedisEstateTradeValue(2L, -5, 990, 112L);
+        when(redisRepository.popOldestBuyOrderFromBoth(1L)).thenReturn(buy);
+        when(redisRepository.popOldestSellOrderFromBoth(1L)).thenReturn(sell);
+
+        RedisEstateTradeValue actualBuy = tradeRedisService.popOldestBuyOrderFromBoth(1L);
+        RedisEstateTradeValue actualSell = tradeRedisService.popOldestSellOrderFromBoth(1L);
+
+        assertThat(actualBuy).isEqualTo(buy);
+        assertThat(actualSell).isEqualTo(sell);
+    }
+
+    /**
+     * [정상 케이스] 매수 주문 이벤트 매칭
+     * - 주문 저장 및 분산 락 동작, 매칭 함수 실행 검증
+     */
+    @Test
+    @DisplayName("매수 주문 이벤트 매칭 - 저장 및 락 동작")
+    void matchNewBuyOrder_success() throws InterruptedException {
+        doNothing().when(redisRepository).saveOrUpdateBuyOrder(any(), anyLong(), any(), anyLong());
         when(redissonClient.getFairLock(anyString())).thenReturn(rLock);
         when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
         when(rLock.isHeldByCurrentThread()).thenReturn(true);
 
-        ExecutorService executor = Executors.newFixedThreadPool(10);
-        CountDownLatch latch = new CountDownLatch(10);
+        // 매칭 시 pop된 주문이 없다는 상황을 가정
+        when(redisRepository.popOldestBuyOrderFromBoth(anyLong())).thenReturn(null);
+        when(redisRepository.popOldestSellOrderFromBoth(anyLong())).thenReturn(null);
 
-        // When
-        for (int i = 0; i < 10; i++) {
+        OrderCreatedEvent event = OrderCreatedEvent.builder()
+                .estateId(1L).customerId(2L).tradeTokenAmount(10).tokenPrice(1000).build();
+
+        assertThatNoException().isThrownBy(() ->
+                tradeRedisService.matchNewBuyOrder(event)
+        );
+        verify(rLock).unlock();
+    }
+
+    /**
+     * [정상 케이스] 매도 주문 이벤트 매칭
+     * - 주문 저장 및 분산 락 동작, 매칭 함수 실행 검증
+     */
+    @Test
+    @DisplayName("매도 주문 이벤트 매칭 - 저장 및 락 동작")
+    void matchNewSellOrder_success() throws InterruptedException {
+        doNothing().when(redisRepository).saveOrUpdateSellOrder(any(), anyLong(), any(), anyLong());
+        when(redissonClient.getFairLock(anyString())).thenReturn(rLock);
+        when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+        when(rLock.isHeldByCurrentThread()).thenReturn(true);
+
+        // 매칭 시 pop된 주문이 없다는 상황을 가정
+        when(redisRepository.popOldestBuyOrderFromBoth(anyLong())).thenReturn(null);
+        when(redisRepository.popOldestSellOrderFromBoth(anyLong())).thenReturn(null);
+
+        OrderCreatedEvent event = OrderCreatedEvent.builder()
+                .estateId(1L).customerId(2L).tradeTokenAmount(10).tokenPrice(1000).build();
+
+        assertThatNoException().isThrownBy(() ->
+                tradeRedisService.matchNewSellOrder(event)
+        );
+        verify(rLock).unlock();
+    }
+
+    /**
+     * [동시성 케이스] 분산 락 획득/해제
+     * - 여러 스레드 환경에서 락 경쟁 및 처리 검증
+     */
+    @Test
+    @DisplayName("분산 락 획득/해제 - 동시성 환경에서 경쟁 처리")
+    void processMatchingWithLock_concurrent() throws InterruptedException {
+        when(redissonClient.getFairLock(anyString())).thenReturn(rLock);
+        when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+        when(rLock.isHeldByCurrentThread()).thenReturn(true);
+        when(redisRepository.popOldestBuyOrderFromBoth(anyLong())).thenReturn(null);
+        when(redisRepository.popOldestSellOrderFromBoth(anyLong())).thenReturn(null);
+
+        ExecutorService executor = Executors.newFixedThreadPool(5);
+        CountDownLatch latch = new CountDownLatch(5);
+
+        for (int i = 0; i < 5; i++) {
             executor.submit(() -> {
                 tradeRedisService.processMatchingWithLock(1L);
                 latch.countDown();
@@ -95,48 +218,40 @@ class TradeRedisServiceImplTest {
         }
         latch.await();
 
-        // Then: 락 획득 10번, 해제 10번
-        verify(rLock, times(10)).tryLock(anyLong(), anyLong(), any(TimeUnit.class));
-        verify(rLock, times(10)).unlock();
+        verify(rLock, atLeastOnce()).tryLock(anyLong(), anyLong(), any(TimeUnit.class));
+        verify(rLock, atLeastOnce()).unlock();
     }
 
     /**
-     * 부분 체결 주문 재삽입 테스트
-     * - 주문을 재삽입할 때 원본 타임스탬프가 유지되는지 검증
-     * - 재삽입된 주문이 정확한 키에 저장되는지 확인
+     * [비정상 케이스] 매칭 도중 매물/고객 미존재
+     * - 체결 시 매물 or 고객 미존재로 예외 발생 검증
      */
     @Test
-    void testPartialOrderReinsertion() {
-        // Given
-        RedisEstateTradeValue order = new RedisEstateTradeValue(100L, 5, 1000, 123456789L);
+    @DisplayName("매칭 도중 매물 또는 고객 미존재 - 예외 발생")
+    void saveTradeTransaction_fail() {
+        // 매물 조회 실패 케이스
+        when(redisRepository.popOldestBuyOrderFromBoth(anyLong()))
+                .thenReturn(new RedisEstateTradeValue(1L, 10, 1000, 111L));
+        when(redisRepository.popOldestSellOrderFromBoth(anyLong()))
+                .thenReturn(new RedisEstateTradeValue(2L, -10, 1000, 112L));
+        when(estateRepository.findById(anyLong())).thenReturn(Optional.empty());
 
-        // When
-        tradeRedisService.reinsertBuyOrder(1L, order);
-
-        // Then: 저장 검증
-        verify(redisRepository).saveOrUpdateBuyOrder(
-                argThat(o -> o.getTimestamp() == 123456789L),
-                eq(1L),
-                any(),
-                eq(100L)
-        );
+        assertThatThrownBy(() -> tradeRedisService.matchAllPossibleOrders(1L))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.ESTATE_NOT_FOUND.getMessage());
     }
 
     /**
-     * 락 획득 실패 시나리오 테스트
-     * - 락 획득에 실패할 경우 매칭 로직이 실행되지 않는지 검증
-     * - 데이터 무결성이 보장되는지 확인
+     * [부분 체결] 부분 주문 재삽입
+     * - pop한 주문이 부분 체결되어 원본 타임스탬프 유지되는지 검증
      */
     @Test
-    void testLockAcquisitionFailure() throws InterruptedException {
-        // Given
-        when(redissonClient.getFairLock(anyString())).thenReturn(rLock);
-        when(rLock.tryLock(anyLong(), anyLong(), any())).thenReturn(false);
+    @DisplayName("부분 체결 후 주문 재삽입 - 원본 타임스탬프 유지")
+    void reinsertOrder_success() {
+        RedisEstateTradeValue buyOrder = new RedisEstateTradeValue(2L, 8, 999, 111L);
+        doNothing().when(redisRepository).saveOrUpdateBuyOrder(any(), anyLong(), any(), anyLong());
 
-        // When
-        tradeRedisService.processMatchingWithLock(1L);
-
-        // Then
-        verify(redisRepository, never()).popOldestBuyOrderFromBoth(anyLong());
+        assertThatNoException().isThrownBy(() -> tradeRedisService.reinsertBuyOrder(1L, buyOrder));
+        verify(redisRepository).saveOrUpdateBuyOrder(any(), eq(1L), any(), eq(2L));
     }
 }

--- a/woorepie/src/test/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImplTest.java
+++ b/woorepie/src/test/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImplTest.java
@@ -1,0 +1,314 @@
+package com.piehouse.woorepie.trade.service.implement;
+
+import com.piehouse.woorepie.customer.entity.Account;
+import com.piehouse.woorepie.customer.entity.Customer;
+import com.piehouse.woorepie.customer.repository.AccountRepository;
+import com.piehouse.woorepie.customer.repository.CustomerRepository;
+import com.piehouse.woorepie.estate.dto.RedisEstatePrice;
+import com.piehouse.woorepie.estate.entity.Estate;
+import com.piehouse.woorepie.estate.entity.EstateStatus;
+import com.piehouse.woorepie.estate.repository.EstateRepository;
+import com.piehouse.woorepie.global.exception.CustomException;
+import com.piehouse.woorepie.global.exception.ErrorCode;
+import com.piehouse.woorepie.global.kafka.dto.OrderCreatedEvent;
+import com.piehouse.woorepie.global.kafka.dto.SubscriptionRequestEvent;
+import com.piehouse.woorepie.global.kafka.dto.TransactionCreatedEvent;
+import com.piehouse.woorepie.global.kafka.service.KafkaProducerService;
+import com.piehouse.woorepie.notification.service.NotificationService;
+import com.piehouse.woorepie.subscription.entity.SubStatus;
+import com.piehouse.woorepie.subscription.entity.Subscription;
+import com.piehouse.woorepie.subscription.repository.SubscriptionRepository;
+import com.piehouse.woorepie.trade.dto.request.BuyEstateRequest;
+import com.piehouse.woorepie.trade.dto.request.CreateSubscriptionTradeRequest;
+import com.piehouse.woorepie.trade.dto.request.RedisCustomerTradeValue;
+import com.piehouse.woorepie.trade.dto.request.RedisEstateTradeValue;
+import com.piehouse.woorepie.trade.dto.request.SellEstateRequest;
+import com.piehouse.woorepie.trade.entity.Trade;
+import com.piehouse.woorepie.trade.repository.RedisTradeRepository;
+import com.piehouse.woorepie.trade.repository.TradeRepository;
+import com.piehouse.woorepie.estate.service.EstateRedisService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("TradeServiceImpl 단위테스트")
+class TradeServiceImplTest {
+
+    @Mock TradeRepository tradeRepository;
+    @Mock AccountRepository accountRepository;
+    @Mock CustomerRepository customerRepository;
+    @Mock RedisTradeRepository redisOrderRepository;
+    @Mock KafkaProducerService kafkaProducerService;
+    @Mock NotificationService notificationService;
+    @Mock EstateRepository estateRepository;
+    @Mock SubscriptionRepository subscriptionRepository;
+    @Mock StringRedisTemplate redisTemplate;
+    @Mock PlatformTransactionManager transactionManager;
+    @Mock EstateRedisService estateRedisService;
+
+    @InjectMocks
+    private TradeServiceImpl tradeService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    /**
+     * [정상 케이스] 거래 내역 저장 및 알림/계좌 처리
+     * - 거래 엔티티 저장 → 이벤트 발행 → 계좌, 잔액 처리까지 정상동작 검증
+     */
+    @Test
+    @DisplayName("saveTrade - 거래 내역 저장 및 알림, 계좌 처리")
+    void saveTrade_success() {
+        Estate estate = mock(Estate.class);
+        Customer seller = mock(Customer.class);
+        Customer buyer = mock(Customer.class);
+        Account sellerAccount = mock(Account.class);
+        Account buyerAccount = mock(Account.class);
+        Trade trade = mock(Trade.class);
+
+        // ID, getter 등 mock 세팅
+        when(seller.getCustomerId()).thenReturn(1L);
+        when(buyer.getCustomerId()).thenReturn(2L);
+        when(estate.getEstateId()).thenReturn(123L);
+        when(estate.getEstateName()).thenReturn("부동산A");
+        when(trade.getEstate()).thenReturn(estate);
+        when(trade.getSeller()).thenReturn(seller);
+        when(trade.getBuyer()).thenReturn(buyer);
+        when(trade.getTokenPrice()).thenReturn(1000);
+        when(trade.getTradeTokenAmount()).thenReturn(5);
+        when(trade.getTradeId()).thenReturn(999L);
+        when(trade.getTradeDate()).thenReturn(LocalDateTime.now());
+
+        when(tradeRepository.save(any())).thenReturn(trade);
+        when(customerRepository.findById(1L)).thenReturn(Optional.of(seller));
+        when(customerRepository.findById(2L)).thenReturn(Optional.of(buyer));
+        when(accountRepository.findByCustomerAndEstate(eq(seller), eq(estate))).thenReturn(Optional.of(sellerAccount));
+        when(accountRepository.findByCustomerAndEstate(eq(buyer), eq(estate))).thenReturn(Optional.of(buyerAccount));
+        when(buyerAccount.getAccountTokenAmount()).thenReturn(0);
+        when(buyerAccount.getTotalAccountAmount()).thenReturn(0);
+        when(sellerAccount.getAccountTokenAmount()).thenReturn(10);
+        when(sellerAccount.getTotalAccountAmount()).thenReturn(10000);
+        when(sellerAccount.updateTokenAmount(anyInt())).thenReturn(sellerAccount);
+        when(sellerAccount.updateTotalAmount(anyInt())).thenReturn(sellerAccount);
+        when(buyerAccount.updateTokenAmount(anyInt())).thenReturn(buyerAccount);
+        when(buyerAccount.updateTotalAmount(anyInt())).thenReturn(buyerAccount);
+
+        // when
+        Trade result = tradeService.saveTrade(estate, seller, buyer, 5, 1000);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(tradeRepository).save(any());
+        verify(kafkaProducerService).sendTransactionCreated(any(TransactionCreatedEvent.class));
+        verify(notificationService, times(2)).sendTradeNotification(any(), anyString(), anyInt(), anyInt(), any(), anyBoolean());
+        verify(sellerAccount).updateTokenAmount(5);
+        verify(sellerAccount).updateTotalAmount(5000);
+        verify(buyerAccount).updateTokenAmount(5);
+        verify(buyerAccount).updateTotalAmount(5000);
+        verify(seller).increaseAccountBalance(5000);
+        verify(buyer).decreaseAccountBalance(5000);
+    }
+
+    /**
+     * [예외 케이스] 거래 저장 - 판매자/구매자 미존재 시 예외
+     * - 고객 조회 결과가 없을 때 예외 반환
+     */
+    @Test
+    @DisplayName("saveTrade - 판매자/구매자 미존재 시 예외")
+    void saveTrade_noUser_fail() {
+        Estate estate = mock(Estate.class);
+        Customer seller = mock(Customer.class);
+        Customer buyer = mock(Customer.class);
+        when(seller.getCustomerId()).thenReturn(1L);
+        when(buyer.getCustomerId()).thenReturn(2L);
+        when(customerRepository.findById(1L)).thenReturn(Optional.empty());
+        when(customerRepository.findById(2L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tradeService.saveTrade(estate, seller, buyer, 1, 1000))
+                .isInstanceOf(CustomException.class);
+    }
+
+    /**
+     * [정상 케이스] 매수 주문 요청 - 잔액 검증 및 Kafka 발행 정상동작
+     */
+    @Test
+    @DisplayName("buy - 매수 요청 성공 및 Kafka 발행")
+    void buy_success() {
+        BuyEstateRequest request = mock(BuyEstateRequest.class);
+        when(request.getTradeTokenAmount()).thenReturn(2);
+        when(request.getTokenPrice()).thenReturn(1000);
+        when(request.getEstateId()).thenReturn(10L);
+
+        Customer customer = mock(Customer.class);
+        when(customerRepository.findById(3L)).thenReturn(Optional.of(customer));
+        when(customer.getAccountBalance()).thenReturn(10000);
+
+        when(redisOrderRepository.getCustomerBuyOrders(3L)).thenReturn(List.of());
+
+        assertThatNoException().isThrownBy(() -> tradeService.buy(request, 3L));
+        verify(kafkaProducerService).sendOrderCreated(any(OrderCreatedEvent.class));
+    }
+
+    /**
+     * [예외 케이스] 매수 요청 실패 - 잔액 부족
+     * - 요청금액이 잔액 초과 시 예외 발생
+     */
+    @Test
+    @DisplayName("buy - 잔액 부족 예외")
+    void buy_insufficientCash_fail() {
+        BuyEstateRequest request = mock(BuyEstateRequest.class);
+        when(request.getTradeTokenAmount()).thenReturn(10);
+        when(request.getTokenPrice()).thenReturn(2000);
+        when(request.getEstateId()).thenReturn(10L);
+
+        Customer customer = mock(Customer.class);
+        when(customerRepository.findById(3L)).thenReturn(Optional.of(customer));
+        when(customer.getAccountBalance()).thenReturn(1000);
+        when(redisOrderRepository.getCustomerBuyOrders(3L)).thenReturn(List.of());
+
+        assertThatThrownBy(() -> tradeService.buy(request, 3L))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.INSUFFICIENT_CASH.getMessage());
+    }
+
+    /**
+     * [정상 케이스] 매도 요청 성공 - 보유량 충분, Kafka 발행 정상
+     */
+    @Test
+    @DisplayName("sell - 매도 요청 성공 및 Kafka 발행")
+    void sell_success() {
+        SellEstateRequest request = mock(SellEstateRequest.class);
+        when(request.getEstateId()).thenReturn(10L);
+        when(request.getTradeTokenAmount()).thenReturn(3);
+        when(request.getTokenPrice()).thenReturn(800);
+
+        Account account = mock(Account.class);
+        when(account.getAccountTokenAmount()).thenReturn(10);
+
+        when(accountRepository.findByCustomer_CustomerIdAndEstate_EstateId(3L, 10L)).thenReturn(Optional.of(account));
+        when(redisOrderRepository.getEstateSellOrders(10L)).thenReturn(List.of());
+
+        assertThatNoException().isThrownBy(() -> tradeService.sell(request, 3L));
+        verify(kafkaProducerService).sendOrderCreated(any(OrderCreatedEvent.class));
+    }
+
+    /**
+     * [예외 케이스] 매도 요청 실패 - 토큰 미보유
+     * - 계좌가 존재하지 않으면 예외 발생
+     */
+    @Test
+    @DisplayName("sell - 토큰 미보유 예외")
+    void sell_tokenNotExist_fail() {
+        SellEstateRequest request = mock(SellEstateRequest.class);
+        when(request.getEstateId()).thenReturn(10L);
+        when(request.getTradeTokenAmount()).thenReturn(5);
+        when(accountRepository.findByCustomer_CustomerIdAndEstate_EstateId(3L, 10L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tradeService.sell(request, 3L))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.TOKEN_NON_EXIST.getMessage());
+    }
+
+    /**
+     * [정상 케이스] 청약 신청 - 잔액 충분, 기간 내 정상 Kafka 발송
+     */
+    @Test
+    @DisplayName("createSubscription - 정상 청약 요청")
+    void createSubscription_success() {
+        CreateSubscriptionTradeRequest request = mock(CreateSubscriptionTradeRequest.class);
+        when(request.getEstateId()).thenReturn(15L);
+        when(request.getSubAmount()).thenReturn(3);
+
+        Customer customer = mock(Customer.class);
+        when(customer.getAccountBalance()).thenReturn(10000);
+        when(customerRepository.findById(99L)).thenReturn(Optional.of(customer));
+
+        Estate estate = mock(Estate.class);
+        when(estateRepository.findById(15L)).thenReturn(Optional.of(estate));
+        when(estate.getSubStartDate()).thenReturn(LocalDateTime.now().minusDays(1));
+        when(estate.getSubEndDate()).thenReturn(LocalDateTime.now().plusDays(1));
+
+        RedisEstatePrice price = mock(RedisEstatePrice.class);
+        when(price.getEstateTokenPrice()).thenReturn(2000);
+        when(estateRedisService.getRedisEstatePrice(15L)).thenReturn(price);
+
+        when(redisOrderRepository.getCustomerBuyOrders(99L)).thenReturn(List.of());
+
+        assertThatNoException().isThrownBy(() -> tradeService.createSubscription(request, 99L));
+        verify(kafkaProducerService).sendSubscriptionRequest(any(SubscriptionRequestEvent.class));
+    }
+
+    /**
+     * [예외 케이스] 청약 신청 실패 - 기간 외 예외
+     * - 청약 기간 외일 때 예외 발생
+     */
+    @Test
+    @DisplayName("createSubscription - 청약 기간 외 예외")
+    void createSubscription_outOfPeriod_fail() {
+        CreateSubscriptionTradeRequest request = mock(CreateSubscriptionTradeRequest.class);
+        when(request.getEstateId()).thenReturn(100L);
+        when(request.getSubAmount()).thenReturn(2);
+
+        Customer customer = mock(Customer.class);
+        when(customer.getAccountBalance()).thenReturn(10000);
+        when(customerRepository.findById(99L)).thenReturn(Optional.of(customer));
+
+        Estate estate = mock(Estate.class);
+        when(estateRepository.findById(100L)).thenReturn(Optional.of(estate));
+        when(estate.getSubStartDate()).thenReturn(LocalDateTime.now().plusDays(2)); // 아직 시작 전
+        when(estate.getSubEndDate()).thenReturn(LocalDateTime.now().plusDays(10));
+
+        assertThatThrownBy(() -> tradeService.createSubscription(request, 99L))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.SUBSCRIPTION_PERIOD_INVALID.getMessage());
+    }
+
+    /**
+     * [정상 케이스] 청약 요청 처리 - RUNNING 상태, 잔액 차감 및 저장 정상
+     */
+    @Test
+    @DisplayName("processSubscriptionRequest - RUNNING 상태에서 청약 처리")
+    void processSubscriptionRequest_success() {
+        Estate estate = mock(Estate.class);
+        when(estateRepository.findById(111L)).thenReturn(Optional.of(estate));
+        when(estate.getEstateStatus()).thenReturn(EstateStatus.RUNNING);
+
+        Customer customer = mock(Customer.class);
+        when(customerRepository.findById(11L)).thenReturn(Optional.of(customer));
+        when(customerRepository.decreaseBalance(eq(11L), anyInt())).thenReturn(1);
+
+        assertThatNoException().isThrownBy(() ->
+                tradeService.processSubscriptionRequest(111L, 11L, 2, 1000)
+        );
+        verify(subscriptionRepository).save(any(Subscription.class));
+    }
+
+    /**
+     * [예외 케이스] 청약 요청 처리 실패 - 매물 상태가 RUNNING 아님
+     * - READY 등 다른 상태면 예외 발생
+     */
+    @Test
+    @DisplayName("processSubscriptionRequest - 상태 비정상 예외")
+    void processSubscriptionRequest_invalidStatus_fail() {
+        Estate estate = mock(Estate.class);
+        when(estateRepository.findById(222L)).thenReturn(Optional.of(estate));
+        when(estate.getEstateStatus()).thenReturn(EstateStatus.READY);
+
+        assertThatThrownBy(() -> tradeService.processSubscriptionRequest(222L, 33L, 2, 1000))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.ESTATE_NOT_RUNNING.getMessage());
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요
- TradeRedisServiceImpl, TradeServiceImpl 주요 서비스 로직에 대한 Mock 기반 단위테스트 코드 추가  

## ✅ 작업 목록

### TradeRedisServiceImpl 단위테스트
- [x] 매수 주문 저장(Lua 스크립트) 테스트
- [x] 매도 주문 저장(Lua 스크립트) 테스트
- [x] 매물 기준 매수/매도 주문 전체 조회 테스트
- [x] 고객 기준 매수/매도 주문 전체 조회 테스트
- [x] 가장 오래된 매수/매도 주문 pop 테스트
- [x] 매수 주문 이벤트 매칭 - 저장 및 락 동작 테스트
- [x] 매도 주문 이벤트 매칭 - 저장 및 락 동작 테스트
- [x] 분산 락 획득/해제 동시성 처리 테스트
- [x] 매칭 도중 매물/고객 미존재 예외 테스트
- [x] 부분 체결 후 주문 재삽입(타임스탬프 보존) 테스트

### TradeServiceImpl 단위테스트
- [x] 거래 내역 저장 및 알림/계좌 처리 테스트
- [x] 거래 저장 실패(판매자/구매자 미존재) 예외 테스트
- [x] 매수 요청 성공 및 Kafka 발행 테스트
- [x] 매수 요청 실패(잔액 부족) 예외 테스트
- [x] 매도 요청 성공 및 Kafka 발행 테스트
- [x] 매도 요청 실패(토큰 미보유) 예외 테스트
- [x] 청약 신청 정상 처리 및 Kafka 발행 테스트
- [x] 청약 신청 기간 외 예외 테스트
- [x] 청약 요청 처리(RUNNING 상태) 테스트
- [x] 청약 요청 처리 실패(매물 상태 비정상) 예외 테스트


## 📎 관련 이슈
- resolve #101