### PR TITLE
[TEST] Notice 서비스 로직 단위 테스트 및 시나리오별 Mock 테스트 추가

### DIFF
--- a/woorepie/src/main/java/com/piehouse/woorepie/notice/controller/NoticeController.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/notice/controller/NoticeController.java
@@ -25,15 +25,6 @@ public class NoticeController {
 
     private final NoticeService noticeService;
 
-    // 공시 등록 (중개인 로그인 필요)
-    @PostMapping("/create")
-    public ResponseEntity<ApiResponse<String>> createNotice(@Valid @RequestBody CreateNoticeRequest request,
-                                                            @AuthenticationPrincipal SessionAgent sessionAgent,
-                                                            HttpServletRequest httpRequest) {
-        noticeService.create(request, sessionAgent.getAgentId());
-        return ApiResponseUtil.of(HttpStatus.CREATED, "공시 등록 성공", null, httpRequest);
-    }
-
     // 공시 리스트 조회
     @GetMapping
     public ResponseEntity<ApiResponse<List<GetNoticeSimpleResponse>>> getNotices(HttpServletRequest request) {
@@ -51,15 +42,4 @@ public class NoticeController {
         return ApiResponseUtil.success(dto, request);
     }
 
-    // 공시 수정 (중개인 로그인 필요)
-    @PatchMapping("/modify")
-    public ResponseEntity<ApiResponse<String>> modifyNotice(
-            @RequestParam("noticeId") Long noticeId,
-            @Valid @RequestBody ModifyNoticeRequest request,
-            @AuthenticationPrincipal SessionAgent sessionAgent,
-            HttpServletRequest httpRequest
-    ) {
-        noticeService.modifyNotice(noticeId, request, sessionAgent.getAgentId());
-        return ApiResponseUtil.success("공시 수정 성공", httpRequest);
-    }
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/notice/service/NoticeService.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/notice/service/NoticeService.java
@@ -9,16 +9,10 @@ import java.util.List;
 
 public interface NoticeService {
 
-    // 공시 등록
-    void create(CreateNoticeRequest request, Long agentId);
-
     // 공시 리스트 조회
     List<GetNoticeSimpleResponse> getNoticeList();
 
     // 공시 상세 조회
     GetNoticeDetailsResponse getNoticeDetails(Long noticeId);
-
-    // 공시 수정
-    void modifyNotice(Long noticeId, ModifyNoticeRequest request, Long agentId);
 
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/notice/service/implement/NoticeServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/notice/service/implement/NoticeServiceImpl.java
@@ -24,25 +24,6 @@ import java.util.stream.Collectors;
 public class NoticeServiceImpl implements NoticeService {
 
     private final NoticeRepository noticeRepository;
-    private final EstateRepository estateRepository;
-
-    @Override
-    @Transactional
-    public void create(CreateNoticeRequest request, Long agentId) {
-
-        Estate estate = estateRepository.findById(request.getEstateId())
-                .orElseThrow(() -> new CustomException(ErrorCode.ESTATE_NOT_FOUND));
-
-        Notice notice = Notice.builder()
-                .estate(estate)
-                .noticeTitle(request.getNoticeTitle())
-                .noticeContent(request.getNoticeContent())
-                .noticeFileUrl(request.getNoticeFileUrl())
-                .noticeDate(LocalDateTime.now())
-                .build();
-        noticeRepository.save(notice);
-
-    }
 
     @Override
     @Transactional(readOnly = true)
@@ -80,21 +61,6 @@ public class NoticeServiceImpl implements NoticeService {
                 .noticeFileUrl(notice.getNoticeFileUrl())
                 .noticeDate(notice.getNoticeDate())
                 .build();
-
-    }
-
-    @Override
-    @Transactional
-    public void modifyNotice(Long noticeId, ModifyNoticeRequest request, Long agentId) {
-
-        Notice notice = noticeRepository.findById(noticeId)
-                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
-
-        notice.updateNotice(
-                request.getNoticeTitle(),
-                request.getNoticeContent(),
-                request.getNoticeFileUrl()
-        );
 
     }
 

--- a/woorepie/src/test/java/com/piehouse/woorepie/notice/service/implement/NoticeServiceImplTest.java
+++ b/woorepie/src/test/java/com/piehouse/woorepie/notice/service/implement/NoticeServiceImplTest.java
@@ -1,0 +1,122 @@
+package com.piehouse.woorepie.notice.service.implement;
+
+import com.piehouse.woorepie.estate.entity.Estate;
+import com.piehouse.woorepie.global.exception.CustomException;
+import com.piehouse.woorepie.global.exception.ErrorCode;
+import com.piehouse.woorepie.notice.dto.response.GetNoticeDetailsResponse;
+import com.piehouse.woorepie.notice.dto.response.GetNoticeSimpleResponse;
+import com.piehouse.woorepie.notice.entity.Notice;
+import com.piehouse.woorepie.notice.repository.NoticeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("NoticeServiceImpl 단위테스트")
+class NoticeServiceImplTest {
+
+    @Mock
+    private NoticeRepository noticeRepository;
+
+    @InjectMocks
+    private NoticeServiceImpl noticeService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    /**
+     * [정상 케이스] 공시 목록 전체 조회
+     * - 공시 엔티티 리스트를 최신순 정렬로 조회, DTO 매핑이 정상 동작하는지 검증
+     */
+    @Test
+    @DisplayName("getNoticeList - 전체 공시 목록 조회 성공")
+    void getNoticeList_success() {
+        // given
+        Estate estate = mock(Estate.class);
+        when(estate.getEstateId()).thenReturn(100L);
+        when(estate.getEstateName()).thenReturn("테스트부동산");
+
+        Notice notice = mock(Notice.class);
+        when(notice.getNoticeId()).thenReturn(1L);
+        when(notice.getEstate()).thenReturn(estate);
+        when(notice.getNoticeTitle()).thenReturn("공시 제목");
+        when(notice.getNoticeDate()).thenReturn(LocalDateTime.of(2024, 6, 1, 10, 0));
+
+        List<Notice> noticeList = List.of(notice);
+        when(noticeRepository.findAllWithEstateOrderByNoticeDateDesc()).thenReturn(noticeList);
+
+        // when
+        List<GetNoticeSimpleResponse> responseList = noticeService.getNoticeList();
+
+        // then
+        assertThat(responseList).hasSize(1);
+        GetNoticeSimpleResponse res = responseList.get(0);
+        assertThat(res.getNoticeId()).isEqualTo(1L);
+        assertThat(res.getEstateId()).isEqualTo(100L);
+        assertThat(res.getEstateName()).isEqualTo("테스트부동산");
+        assertThat(res.getNoticeTitle()).isEqualTo("공시 제목");
+        assertThat(res.getNoticeDate()).isEqualTo(LocalDateTime.of(2024, 6, 1, 10, 0));
+        verify(noticeRepository).findAllWithEstateOrderByNoticeDateDesc();
+    }
+
+    /**
+     * [정상 케이스] 공시 상세 조회
+     * - 공시 ID로 조회하여 상세 DTO 변환이 정상 동작하는지 검증
+     */
+    @Test
+    @DisplayName("getNoticeDetails - 공시 상세 조회 성공")
+    void getNoticeDetails_success() {
+        // given
+        Estate estate = mock(Estate.class);
+        when(estate.getEstateId()).thenReturn(99L);
+        when(estate.getEstateName()).thenReturn("우리빌라");
+
+        Notice notice = mock(Notice.class);
+        when(notice.getNoticeId()).thenReturn(11L);
+        when(notice.getEstate()).thenReturn(estate);
+        when(notice.getNoticeTitle()).thenReturn("상세공시");
+        when(notice.getNoticeContent()).thenReturn("내용입니다.");
+        when(notice.getNoticeFileUrl()).thenReturn("http://file.url/abc.png");
+        when(notice.getNoticeDate()).thenReturn(LocalDateTime.of(2024, 6, 2, 9, 0));
+
+        when(noticeRepository.findById(11L)).thenReturn(Optional.of(notice));
+
+        // when
+        GetNoticeDetailsResponse response = noticeService.getNoticeDetails(11L);
+
+        // then
+        assertThat(response.getNoticeId()).isEqualTo(11L);
+        assertThat(response.getEstateId()).isEqualTo(99L);
+        assertThat(response.getEstateName()).isEqualTo("우리빌라");
+        assertThat(response.getNoticeTitle()).isEqualTo("상세공시");
+        assertThat(response.getNoticeContent()).isEqualTo("내용입니다.");
+        assertThat(response.getNoticeFileUrl()).isEqualTo("http://file.url/abc.png");
+        assertThat(response.getNoticeDate()).isEqualTo(LocalDateTime.of(2024, 6, 2, 9, 0));
+        verify(noticeRepository).findById(11L);
+    }
+
+    /**
+     * [예외 케이스] 공시 상세 조회 - 존재하지 않는 경우
+     * - 조회 결과가 없으면 CustomException이 발생하는지 검증
+     */
+    @Test
+    @DisplayName("getNoticeDetails - 공시 미존재 예외")
+    void getNoticeDetails_notFound() {
+        // given
+        when(noticeRepository.findById(99L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> noticeService.getNoticeDetails(99L))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.RESOURCE_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요
- NoticeServiceImpl(공시 서비스) 주요 서비스 로직 단위 테스트 코드 추가
- 전체/상세/예외 등 정상·비정상 플로우 검증

## ✅ 작업 목록
- [x] Admin WAS에서 처리하여 불필요한 코드 제거
- [x] 전체 공시 목록 조회(getNoticeList) 테스트
- [x] 공시 상세 조회(getNoticeDetails) 테스트
- [x] 공시 상세 조회 실패(미존재) 예외 테스트

## 📎 관련 이슈
- resolve #107 
