### PR TITLE
[FIX] 청약 매물 리스트 조회 필터 수정

### DIFF
--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/entity/EstateStatus.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/entity/EstateStatus.java
@@ -3,7 +3,7 @@ package com.piehouse.woorepie.estate.entity;
 public enum EstateStatus {
     READY, // 청약 등록 대기
     RUNNING, // 청약 중
-    PENDING, // 청약 완료 (승인 대기)
+//    PENDING, // 청약 완료 (승인 대기)
     SUCCESS, // 청약 완료 (승인 완료)
     FAILURE,// 청약 실패
     EXIT // 매각 완료(추후 거래 불가)

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/dto/response/GetSubscriptionSimpleResponse.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/dto/response/GetSubscriptionSimpleResponse.java
@@ -21,6 +21,8 @@ public class GetSubscriptionSimpleResponse {
 
     private String agentName;
 
+    private String businessName;
+
     private LocalDateTime subStartDate;
 
     private LocalDateTime subEndDate;

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
@@ -101,7 +101,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     public List<GetSubscriptionSimpleResponse> getActiveSubscriptions() {
 
         List<Estate> estates = estateRepository.findByEstateStatusIn(List.of(
-                EstateStatus.READY, EstateStatus.RUNNING, EstateStatus.PENDING, EstateStatus.FAILURE
+                EstateStatus.RUNNING, EstateStatus.SUCCESS, EstateStatus.FAILURE, EstateStatus.EXIT
         )); // 청약 중인 substate 필터링
 
         List<Long> estateIds = estates.stream()
@@ -109,7 +109,6 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                 .toList();
 
         Map<Long, RedisEstatePrice> estatePriceMap = estateRedisServiceImpl.getMultipleRedisEstatePrice(estateIds);
-
 
         return estates.stream()
                 .map(estate -> {

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
@@ -119,6 +119,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                             .estateName(estate.getEstateName())
                             .agentId(estate.getAgent().getAgentId())
                             .agentName(estate.getAgent().getAgentName())
+                            .businessName(estate.getAgent().getBusinessName())
                             .subStartDate(estate.getSubStartDate())
                             .subEndDate(estate.getSubEndDate())
                             .estateState(estate.getEstateState())


### PR DESCRIPTION
## ✨ 작업 개요
 청약 매물 리스트 조회 필터 수정
- 청약 중, 청약 성공/실패, 매각 모두 보여주기 (매물 승인 전만 제외)

## ✅ 작업 목록
- [x] 청약 매물 리스트 조회 필터 수정

## 📎 관련 이슈
- 관련 이슈: #120