### PR TITLE
[FEAT] Lua 스크립트 기반 청약 매물의 남은 토큰 수량 감소 처리 로직 추가

### DIFF
--- a/woorepie/src/main/java/com/piehouse/woorepie/customer/repository/CustomerRepository.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/customer/repository/CustomerRepository.java
@@ -22,10 +22,10 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
 
     @Modifying
     @Query("UPDATE Customer c SET c.accountBalance = c.accountBalance - :amount WHERE c.customerId = :customerId AND c.accountBalance >= :amount")
-    long decreaseBalance(@Param("customerId") Long customerId, @Param("amount") long amount);
+    int decreaseBalance(@Param("customerId") Long customerId, @Param("amount") long amount);
 
     @Modifying
     @Query("UPDATE Customer c SET c.accountBalance = c.accountBalance + :amount WHERE c.customerId = :customerId")
-    long increaseBalance(@Param("customerId") Long customerId, @Param("amount") long amount);
+    int increaseBalance(@Param("customerId") Long customerId, @Param("amount") long amount);
 
 }

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/controller/EstateController.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/controller/EstateController.java
@@ -1,9 +1,7 @@
 package com.piehouse.woorepie.estate.controller;
 
-import com.piehouse.woorepie.estate.dto.response.GetBuildingInfoResponse;
-import com.piehouse.woorepie.estate.dto.response.GetEstateDetailsResponse;
-import com.piehouse.woorepie.estate.dto.response.GetEstatePriceResponse;
-import com.piehouse.woorepie.estate.dto.response.GetEstateSimpleResponse;
+import com.piehouse.woorepie.estate.dto.response.*;
+import com.piehouse.woorepie.estate.service.EstateRedisService;
 import com.piehouse.woorepie.estate.service.EstateService;
 import com.piehouse.woorepie.global.response.ApiResponse;
 import com.piehouse.woorepie.global.response.ApiResponseUtil;
@@ -35,6 +33,7 @@ import java.util.Locale;
 public class EstateController {
 
     private final EstateService estateService;
+    private final EstateRedisService estateRedisService;
 
     @Value("${vworld.api.key}")
     private String vWorldApiKey;
@@ -57,6 +56,14 @@ public class EstateController {
         return ApiResponseUtil.success(response, request);
     }
 
+    @GetMapping("/remain/token")
+    public ResponseEntity<ApiResponse<GetRemainingTokensResponse>> getRemainingTokens(
+            @RequestParam Long estateId,
+            HttpServletRequest request) {
+
+        Long remainingTokens = estateRedisService.getRemainingTokensOrInit(estateId);
+        return ApiResponseUtil.success(new GetRemainingTokensResponse(remainingTokens), request);
+    }
     /**
      * 실시간 공시지가 및 건물 정보 조회
      */

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/dto/response/GetRemainingTokensResponse.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/dto/response/GetRemainingTokensResponse.java
@@ -1,0 +1,12 @@
+package com.piehouse.woorepie.estate.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GetRemainingTokensResponse {
+    private Long remainingTokens;
+}

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/repository/EstateRepository.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/repository/EstateRepository.java
@@ -3,6 +3,8 @@ package com.piehouse.woorepie.estate.repository;
 import com.piehouse.woorepie.estate.entity.Estate;
 import com.piehouse.woorepie.estate.entity.EstateStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,8 +12,9 @@ import java.util.Optional;
 
 @Repository
 public interface EstateRepository extends JpaRepository<Estate, Long> {
-    
-    Optional<Long> findTokenAmountByEstateId(Long estateId);
+
+    @Query("SELECT e.tokenAmount FROM Estate e WHERE e.estateId = :estateId")
+    Optional<Long> findTokenAmountByEstateId(@Param("estateId") Long estateId);
     
     List<Estate> findByEstateStatus(EstateStatus estateStatus);
 

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/service/EstateRedisService.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/service/EstateRedisService.java
@@ -6,20 +6,14 @@ import java.util.List;
 import java.util.Map;
 
 public interface EstateRedisService {
-    // 청약 오픈 시 PostgreSQL에서 tokenAmount를 읽어와 Redis에 초기화
-    void initializeRemainingTokens(Long estateId);
+    // 남은 토큰 수량 Redis에서 조회 및 초기화
+    Long getRemainingTokensOrInit(Long estateId);
 
-    // 남은 토큰 수량 Reids에 저장 (STRING)
-    void setRemainingTokens(String estateId, long remainingTokens);
-
-    // 남은 토큰 수량 Redis에서 조회
-    long getRemainingTokens(String estateId);
-
-    // 토큰 수량 감소 (원자적 연산)
-    Long decrementTokens(String estateId, long amount);
+    // Lua Script 기반 감소 메서드
+    Long decrementButNotNegative(Long estateId, long amount);
 
     // 토큰 수량 증가 (원자적 연산)
-    Long incrementTokens(String estateId, long amount);
+    Long incrementTokens(Long estateId, long amount);
 
     // 매물 시세 조회
     RedisEstatePrice getRedisEstatePrice(Long estateId);

--- a/woorepie/src/main/java/com/piehouse/woorepie/estate/service/implement/EstateRedisServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/estate/service/implement/EstateRedisServiceImpl.java
@@ -3,17 +3,17 @@ package com.piehouse.woorepie.estate.service.implement;
 import com.piehouse.woorepie.estate.dto.RedisEstatePrice;
 import com.piehouse.woorepie.estate.entity.Dividend;
 import com.piehouse.woorepie.estate.entity.Estate;
-import com.piehouse.woorepie.estate.entity.EstatePrice;
 import com.piehouse.woorepie.estate.repository.DividendRepository;
-import com.piehouse.woorepie.estate.repository.EstatePriceRepository;
 import com.piehouse.woorepie.estate.repository.EstateRepository;
 import com.piehouse.woorepie.estate.service.EstateRedisService;
 import com.piehouse.woorepie.global.exception.CustomException;
 import com.piehouse.woorepie.global.exception.ErrorCode;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,45 +31,48 @@ public class EstateRedisServiceImpl implements EstateRedisService {
     private final RedisTemplate<String, String> redisStringTemplate;
     private final RedisTemplate<String, Object> redisObjectTemplate;
     private final EstateRepository estateRepository;
-    private final EstatePriceRepository estatePriceRepository;
     private final DividendRepository dividendRepository;
     private static final String REDIS_ESTATE_PRICE_KEY_PREFIX = "estate:price:";
+    private static final String REMAINING_TOKENS_KEY_FORMAT = "estate:%s:remainingTokens";
 
-    private static final String REMAINING_TOKENS_KEY_FORMAT = "subscription:%s:remaining-tokens"; // estateId
 
-    // 청약 오픈 시 PostgreSQL에서 tokenAmount를 읽어와 Redis에 초기화
-    @Transactional(readOnly = true)
-    public void initializeRemainingTokens(Long estateId) {
-        // 1. DB에서 tokenAmount 조회
-        Long tokenAmount = estateRepository.findTokenAmountByEstateId(estateId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ESTATE_NOT_FOUND));
+    private DefaultRedisScript<Long> decrementScript; // Lua Script용 필드
 
-        // 2. Redis에 저장 (초기화)
-        String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
-        redisStringTemplate.opsForValue().set(key, String.valueOf(tokenAmount));
+    // Lua Script 초기화
+    @PostConstruct
+    public void initDecrementScript() {
+        decrementScript = new DefaultRedisScript<>();
+        decrementScript.setLocation(new ClassPathResource("scripts/decrement_if_possible.lua"));
+        decrementScript.setResultType(Long.class);
     }
 
-    // 남은 토큰 수량 Reids에 저장 (STRING)
-    public void setRemainingTokens(String estateId, long remainingTokens) {
-        String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
-        redisStringTemplate.opsForValue().set(key, String.valueOf(remainingTokens));
-    }
-
-    // 남은 토큰 수량 Redis에서 조회
-    public long getRemainingTokens(String estateId) {
+    // 남은 토큰 수량 Redis에서 조회 및 초기화
+    @Override
+    public Long getRemainingTokensOrInit(Long estateId) {
         String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
         String value = redisStringTemplate.opsForValue().get(key);
-        return value != null ? Long.parseLong(value) : 0L;
+        if (value != null) return Long.parseLong(value);
+
+        Long tokenAmount = estateRepository.findTokenAmountByEstateId(estateId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ESTATE_NOT_FOUND));
+        redisStringTemplate.opsForValue().setIfAbsent(key, String.valueOf(tokenAmount));
+        return tokenAmount;
     }
 
-    // 토큰 수량 감소 (원자적 연산)
-    public Long decrementTokens(String estateId, long amount) {
+    // Lua Script 기반 감소 메서드
+    @Override
+    public Long decrementButNotNegative(Long estateId, long amount) {
         String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
-        return redisStringTemplate.opsForValue().decrement(key, amount);
+        return redisStringTemplate.execute(
+                decrementScript,
+                Collections.singletonList(key),
+                String.valueOf(amount)
+        );
     }
 
     // 토큰 수량 증가 (원자적 연산)
-    public Long incrementTokens(String estateId, long amount) {
+    @Override
+    public Long incrementTokens(Long estateId, long amount) {
         String key = String.format(REMAINING_TOKENS_KEY_FORMAT, estateId);
         return redisStringTemplate.opsForValue().increment(key, amount);
     }

--- a/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/subscription/service/implement/SubscriptionServiceImpl.java
@@ -336,7 +336,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     // 환불 처리 메소드
     public void refundSubscriptionFailure(Subscription failSub, long tokenPrice) {
         long refundAmount = failSub.getSubTokenAmount() * tokenPrice;
-        long updatedRows = customerRepository.increaseBalance(failSub.getCustomer().getCustomerId(), refundAmount);
+        int updatedRows = customerRepository.increaseBalance(failSub.getCustomer().getCustomerId(), refundAmount);
         if (updatedRows == 0) {
             throw new CustomException(ErrorCode.ACCOUNT_NON_EXIST);
         }

--- a/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
+++ b/woorepie/src/main/java/com/piehouse/woorepie/trade/service/implement/TradeServiceImpl.java
@@ -28,9 +28,7 @@ import com.piehouse.woorepie.trade.repository.TradeRepository;
 import com.piehouse.woorepie.trade.service.TradeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 import com.piehouse.woorepie.subscription.repository.SubscriptionRepository;
 import com.piehouse.woorepie.estate.service.EstateRedisService;
@@ -52,9 +50,6 @@ public class TradeServiceImpl implements TradeService {
     private final NotificationService notificationService;
     private final EstateRepository estateRepository;
     private final SubscriptionRepository subscriptionRepository;
-    private final StringRedisTemplate redisTemplate;
-    private final PlatformTransactionManager transactionManager;
-    private static final String REMAINING_TOKENS_KEY_FORMAT = "subscription:%s:remaining-tokens";
     private final EstateRedisService estateRedisService;
 
     @Override
@@ -335,7 +330,7 @@ public class TradeServiceImpl implements TradeService {
 
         // 3. 고객 계좌 차감
         long totalPrice = requestedAmount * tokenPrice;
-        long updatedRows = customerRepository.decreaseBalance(customerId, totalPrice);
+        int updatedRows = customerRepository.decreaseBalance(customerId, totalPrice);
 
         if (updatedRows == 0) {
             throw new CustomException(ErrorCode.INSUFFICIENT_CASH);
@@ -351,6 +346,8 @@ public class TradeServiceImpl implements TradeService {
                 .build();
         subscriptionRepository.save(subscription);
         log.info("청약 요청 DB에 저장 성공 - estateId: {}, customerId: {}", estateId, customerId);
+
+        estateRedisService.decrementButNotNegative(estateId, requestedAmount);
     }
 
 }

--- a/woorepie/src/main/resources/scripts/decrement_if_possible.lua
+++ b/woorepie/src/main/resources/scripts/decrement_if_possible.lua
@@ -1,0 +1,11 @@
+local current = redis.call("get", KEYS[1])
+if not current then return -1 end
+
+local newVal = tonumber(current) - tonumber(ARGV[1])
+if newVal < 0 then
+    redis.call("set", KEYS[1], 0)
+    return 0
+else
+    redis.call("set", KEYS[1], newVal)
+    return newVal
+end


### PR DESCRIPTION
## ✨ 작업 개요
- Redis Lua 스크립트를 활용해 청약 매물의 남은 토큰 수량을 원자적으로 감소시키는 기능 추가
- Redis에 값이 없을 경우 DB에서 조회 후 초기화
- 남은 토큰 수량이 0 이하로 내려가지 않도록 처리

## ✅ 작업 목록
- [x] Lua 스크립트 decrement_if_possible.lua 작성 (음수 방지 포함)
- [x] decrementButNotNegative() 메서드 구현 및 서비스 적용
- [x] Redis에 값 없을 때 DB에서 초기화하는 getRemainingTokensOrInit() 메서드 구현
- [x] 청약 신청 로직에 Redis 감소 처리 로직 적용

## 📎 관련 이슈
- resolve #123 